### PR TITLE
Fix clippy warning about unnecessary closure

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -70,7 +70,7 @@ impl SnapshotUploader {
         let min_volume_size = cmp::max((file_size + GIBIBYTE - 1) / GIBIBYTE, 1);
 
         // If a volume size was provided, make sure it will be big enough.
-        let volume_size = volume_size.unwrap_or_else(|| min_volume_size);
+        let volume_size = volume_size.unwrap_or(min_volume_size);
         ensure!(
             volume_size >= min_volume_size,
             error::BadVolumeSize {


### PR DESCRIPTION
*Description of changes:*

This should allow the dependabot PRs to check clean.

*Testing done:*

`cargo clippy` is now clean.

Uploaded a snapshot OK, without specifying volume size, so this code path was hit.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
