### PR TITLE
fix download filepath bug

### DIFF
--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -40,15 +40,15 @@ async fn run() -> Result<()> {
             let client = build_client!(EbsClient, args.region, args.endpoint, args.profile)?;
             let downloader = SnapshotDownloader::new(client);
             ensure!(
-                download_args.filename.file_name().is_some(),
+                download_args.file.file_name().is_some(),
                 error::ValidateFilename {
-                    path: download_args.filename
+                    path: download_args.file
                 }
             );
             ensure!(
-                download_args.force || !download_args.filename.exists(),
+                download_args.force || !download_args.file.exists(),
                 error::FileExists {
-                    path: download_args.filename
+                    path: download_args.file
                 }
             );
 
@@ -56,7 +56,7 @@ async fn run() -> Result<()> {
             downloader
                 .download_to_file(
                     &download_args.snapshot_id,
-                    &download_args.filename,
+                    &download_args.file,
                     progress_bar,
                 )
                 .await
@@ -74,7 +74,7 @@ async fn run() -> Result<()> {
             let progress_bar = build_progress_bar(upload_args.no_progress, "Uploading");
             let snapshot_id = uploader
                 .upload_from_file(
-                    &upload_args.filename,
+                    &upload_args.file,
                     upload_args.volume_size,
                     upload_args.description.as_deref(),
                     progress_bar,
@@ -159,7 +159,7 @@ struct DownloadArgs {
     snapshot_id: String,
 
     #[argh(positional)]
-    filename: PathBuf,
+    file: PathBuf,
 
     #[argh(switch)]
     /// overwrite an existing file
@@ -175,7 +175,7 @@ struct DownloadArgs {
 /// Upload a local file into an EBS snapshot.
 struct UploadArgs {
     #[argh(positional)]
-    filename: PathBuf,
+    file: PathBuf,
 
     #[argh(option)]
     /// the size of the volume

--- a/src/download.rs
+++ b/src/download.rs
@@ -57,7 +57,7 @@ impl SnapshotDownloader {
         progress_bar: Option<ProgressBar>,
     ) -> Result<()> {
         let path = path.as_ref();
-        let target_file = path.file_name().context(error::ValidateFileName { path })?;
+        let _ = path.file_name().context(error::ValidateFileName { path })?;
         let target_dir = path
             .parent()
             .context(error::ValidateParentDirectory { path })?;
@@ -167,8 +167,8 @@ impl SnapshotDownloader {
         }
 
         temp_path
-            .persist(target_file)
-            .context(error::PersistTempFile { path: target_file })?;
+            .persist(&path)
+            .context(error::PersistTempFile { path })?;
 
         Ok(())
     }


### PR DESCRIPTION

*Issue #, if available:*

Closes #38 

*Description of changes:*

This fixes a bug where downloading to /some/path/file.bin was not respected. only the filename was considered and file.bin would be placed in the local directory.

I also changed the name of the positional argument `filename` in both download and upload to `file` which feels like a canonical and accurate way to say that we are accepting a path.

In `src/download.rs` at (currently, line 60), I'm not sure why we validate that the file_name is UTF-8, I could remove that check if we want.

*Testing*

```sh
cargo run -- download snap-xxxf0xxx349xxxab1 /tmp/snap.bin
cargo run -- upload  /tmp/snap.bin
```

The above commands worked (I was not running from /tmp) and previously they would not.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
