### PR TITLE
Fix clippy warning about inconsistent field ordering

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -301,8 +301,8 @@ impl SnapshotDownloader {
             data_length > 0 && data_length <= block_size && data_length == block_data_length,
             error::UnexpectedBlockDataLength {
                 snapshot_id,
-                data_length,
                 block_index,
+                data_length,
             }
         );
 


### PR DESCRIPTION
*Description of changes:*

Fixes [this](https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor) new clippy lint that's causing CI failures.  clippy passed locally with this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
