### PR TITLE
cargo update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.1] - 2021-05-13
 ### Changed
 - Add backoff-retry behavior to coldsnap uploads.  [#56]
-- Update dependencies.  [#48], [#50], [#51], [#54], [#55], [#58]
+- Update dependencies.  [#48], [#50], [#51], [#54], [#55], [#58], [#60]
 - Fix clippy warnings for Rust 1.52.  [#57]
 
 ## [0.3.0] - 2021-02-25
@@ -41,3 +41,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#56]: https://github.com/awslabs/coldsnap/pull/56
 [#57]: https://github.com/awslabs/coldsnap/pull/57
 [#58]: https://github.com/awslabs/coldsnap/pull/58
+[#60]: https://github.com/awslabs/coldsnap/pull/60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f508f5ff4df34cfd12172af9f98f5c307db8b36ceb0c63264eccb43be5ed635"
+checksum = "281f563b2c3a0e535ab12d81d3c5859045795256ad269afa7c19542585b68f93"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
*Description of changes:*

An hour ago, after #58, `cpufeatures` was updated and the prior version was yanked, so it felt appropriate to do another quick cargo update.  `cargo test` still passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
