### PR TITLE
Add license check job to runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,3 +26,10 @@ jobs:
       - run: rustup update stable
       - run: cargo build --features rusoto-native-tls --no-default-features --locked
       - run: cargo test --features rusoto-native-tls --no-default-features --locked
+  check-licenses:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: rustup update stable
+    - run: cargo install --version 0.6.2 cargo-deny --no-default-features
+    - run: cargo deny check --disable-fetch licenses

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,37 @@
+[licenses]
+unlicensed = "deny"
+
+# Deny licenses unless they are specifically listed here
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93
+
+allow = [
+    "Apache-2.0",
+    #"BSD-2-Clause", # OK but currently unused; commenting to prevent warning
+    "BSD-3-Clause",
+    "BSL-1.0",
+    #"CC0-1.0",  # OK but currently unused; commenting to prevent warning
+    "ISC",
+    "MIT",
+    "OpenSSL",
+    "Unlicense",
+    #"Zlib",  # OK but currently unused; commenting to prevent warning
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]


### PR DESCRIPTION
*Description of changes:*

Adds a `check-licenses` job to the GitHub Actions runner, which leverages `cargo-deny` to verify that all crates and their dependencies have compatible licenses.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
