### PR TITLE
Speed up check-licenses with caching

### DIFF
--- a/.github/cache_bust
+++ b/.github/cache_bust
@@ -1,0 +1,4 @@
+# this file provides a manual way to clear out github actions caches. any change
+# to this file will cause all github action caches to miss. increment the number
+# below by 1 if you need to clear the caches.
+1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - id: cache-cargo-deny
+      uses: actions/cache@v2
+      with:
+        path: ~/.cargo/bin/cargo-deny
+        # you can edit the .github/cache_bust file if you need to clear the cache
+        key: ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-
     - run: rustup update stable
-    - run: cargo install --version 0.6.2 cargo-deny --no-default-features
+    - if: steps.cache-cargo-deny.outputs.cache-hit != 'true'
+      run: cargo install --version 0.6.2 cargo-deny --no-default-features
     - run: cargo deny check --disable-fetch licenses


### PR DESCRIPTION
*Description of changes:*

`cargo-deny` can take a few minutes to build. This commit will cache the
`cargo-deny` binary and only `cargo install` if necessary.

The cache is keyed off of `Cargo.lock`, but includes a partial key restore
so a cache is still used even when `Cargo.lock` changes. It will then
create a new cache for future builds of the same `Cargo.lock`.

A file named `cache_bust` is added to the `.github` folder. Any edit to that
file will cause a complete cache miss. We can use this to start over if
we ever run into trouble.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
