### PR TITLE
Recommend installing coldsnap with --locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run `coldsnap --help` to see more options.
 ## Installation
 `coldsnap` can be installed with `cargo`.
 ```
-$ cargo install coldsnap
+$ cargo install --locked coldsnap
 ```
 
 ## Security


### PR DESCRIPTION
```
Using `--locked` means cargo will use the dependency versions in our Cargo.lock file.  This is important because newer dependencies may not always compile or function properly until we're ready for them.
```

See https://github.com/awslabs/coldsnap/pull/78 - users are currently unable to `cargo install coldsnap` without `--locked`.

**Testing done:**

Confirmed install failure, then confirmed success with the updated command.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
