### PR TITLE
add support for downloading to block devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,10 +111,12 @@ name = "coldsnap"
 version = "0.3.2"
 dependencies = [
  "argh",
+ "async-trait",
  "base64",
  "bytes",
  "futures",
  "indicatif",
+ "nix",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_ebs",
@@ -609,6 +611,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +657,19 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = "0.9.5"
 bytes = "1"
 base64 = "0.13.0"
 futures = "0.3.16"
+nix = "0.21.0"
 rusoto_core = { version = "0.47.0", default-features = false }
 rusoto_credential = "0.47.0"
 rusoto_ebs = { version = "0.47.0", default-features = false }
@@ -29,3 +30,4 @@ rusoto_signature = "0.47.0"
 snafu = "0.6.9"
 indicatif = "0.16.2"
 tempfile = "3.1.0"
+async-trait = "0.1.50"


### PR DESCRIPTION
*Issue #, if available:* Support reading and writing to volumes #84

*Description of changes:* The changes include adding an in-place option when downloading a snapshot. The in-place option will allow a snapshot to directly be downloaded to a file as opposed to first downloading it to a temp file and then copying it over to the destination file. This change allows customers to directly recover EBS volumes from a snapshot using the raw device name such as /dev/nvme1n1. Customers can use this option to improve their EBS volume restore performance by directly recovering data from a snapshot to an EBS volume. The in-place option can only be used if the file already exists. I tested my changes and ensured the capabiity works as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
