### PR TITLE
add support for uploading from a block device

### DIFF
--- a/src/block_device.rs
+++ b/src/block_device.rs
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+Block device helper functions.
+*/
+
+use snafu::{ensure, ResultExt, Snafu};
+use std::convert::TryFrom;
+use std::fs::OpenOptions;
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
+
+#[derive(Debug, Snafu)]
+pub struct Error(error::Error);
+type Result<T> = std::result::Result<T, Error>;
+
+/// Generates the blkgetsize64 function.
+mod ioctl {
+    use nix::ioctl_read;
+    ioctl_read!(blkgetsize64, 0x12, 114, u64);
+}
+
+/// Find the size of a block device.
+pub(crate) fn get_block_device_size(path: &Path) -> Result<i64> {
+    let file = OpenOptions::new()
+        .read(true)
+        .open(path)
+        .context(error::OpenFile { path })?;
+
+    let mut block_device_size = 0;
+    let result = unsafe { ioctl::blkgetsize64(file.as_raw_fd(), &mut block_device_size) }
+        .context(error::GetBlockDeviceSize { path })?;
+    ensure!(result == 0, error::InvalidBlockDeviceSize { result });
+
+    let block_device_size =
+        i64::try_from(block_device_size).with_context(|| error::ConvertNumber {
+            what: "block device size",
+            number: block_device_size.to_string(),
+            target: "i64",
+        })?;
+    Ok(block_device_size)
+}
+
+/// Potential errors from block device helper functions.
+mod error {
+    use snafu::Snafu;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum Error {
+        #[snafu(display("Failed to open '{}': {}", path.display(), source))]
+        OpenFile {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to get block device size for '{}': {}", path.display(), source))]
+        GetBlockDeviceSize { path: PathBuf, source: nix::Error },
+
+        #[snafu(display("Invalid block device size: {}", result))]
+        InvalidBlockDeviceSize { result: i32 },
+
+        #[snafu(display("Failed to convert {} {} to {}: {}", what, number, target, source))]
+        ConvertNumber {
+            what: String,
+            number: String,
+            target: String,
+            source: std::num::TryFromIntError,
+        },
+    }
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -391,6 +391,159 @@ struct BlockContext {
     ebs_client: EbsClient,
 }
 
+/// Shared interface for write targets.
+#[async_trait]
+trait SnapshotWriteTarget: AsRef<Path> {
+    // grow the target to the desired length
+    async fn grow(&mut self, length: i64) -> Result<()>;
+
+    // returns the file path to which blocks must be written
+    fn write_path(&self) -> Result<&Path>;
+
+    // persist the contents to disk
+    fn finalize(&mut self) -> Result<()>;
+}
+
+/// Implements file operations for block devices.
+struct BlockDeviceTarget {
+    path: PathBuf,
+}
+
+impl BlockDeviceTarget {
+    fn new_target<P: AsRef<Path>>(path: P) -> Result<Box<dyn SnapshotWriteTarget>> {
+        let path = path.as_ref();
+        Ok(Box::new(BlockDeviceTarget { path: path.into() }))
+    }
+
+    async fn is_valid<P: AsRef<Path>>(path: P) -> Result<bool> {
+        let path = path.as_ref();
+        if !path.exists() {
+            return Ok(false);
+        }
+
+        let file_meta = fs::metadata(path)
+            .await
+            .context(error::ReadFileMetadata { path })?;
+
+        if file_meta.file_type().is_block_device() {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl AsRef<Path> for BlockDeviceTarget {
+    fn as_ref(&self) -> &Path {
+        self.path.as_ref()
+    }
+}
+
+#[async_trait]
+impl SnapshotWriteTarget for BlockDeviceTarget {
+    // ensures existing size >= length, but otherwise leaves untouched
+    async fn grow(&mut self, length: i64) -> Result<()> {
+        let path = self.as_ref();
+        let block_device_size = get_block_device_size(path).context(error::GetBlockDeviceSize)?;
+
+        // Make sure the block device is big enough to hold the snapshot
+        ensure!(
+            block_device_size >= length,
+            error::BlockDeviceTooSmall {
+                block_device_size: block_device_size / GIBIBYTE,
+                needed: length / GIBIBYTE,
+            }
+        );
+
+        Ok(())
+    }
+
+    // returns the file path to which blocks must be written
+    fn write_path(&self) -> Result<&Path> {
+        Ok(self.as_ref())
+    }
+
+    // no-op
+    fn finalize(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Implements file operations for filesystem files.
+struct FileTarget {
+    path: PathBuf,
+    temp_file: Option<NamedTempFile>,
+}
+
+impl FileTarget {
+    fn new_target<P: AsRef<Path>>(path: P) -> Result<Box<dyn SnapshotWriteTarget>> {
+        let path = path.as_ref();
+        Ok(Box::new(FileTarget {
+            path: path.into(),
+            temp_file: None,
+        }))
+    }
+}
+
+impl AsRef<Path> for FileTarget {
+    fn as_ref(&self) -> &Path {
+        self.path.as_ref()
+    }
+}
+
+#[async_trait]
+impl SnapshotWriteTarget for FileTarget {
+    // truncate file to desired size
+    async fn grow(&mut self, length: i64) -> Result<()> {
+        let path = self.as_ref();
+
+        // Create a temporary file and extend it to the required size.
+        let target_dir = path
+            .parent()
+            .context(error::ValidateParentDirectory { path })?;
+
+        let temp_file = NamedTempFile::new_in(target_dir)
+            .context(error::CreateTempFile { path: target_dir })?;
+
+        let temp_file_len = length;
+        let temp_file_len = u64::try_from(temp_file_len).with_context(|| error::ConvertNumber {
+            what: "temp file length",
+            number: temp_file_len.to_string(),
+            target: "u64",
+        })?;
+
+        temp_file
+            .as_file()
+            .set_len(temp_file_len)
+            .context(error::ExtendTempFile {
+                path: temp_file.as_ref(),
+            })?;
+
+        self.temp_file.replace(temp_file);
+
+        Ok(())
+    }
+
+    fn write_path(&self) -> Result<&Path> {
+        let write_path = self.temp_file.as_ref().context(error::MissingTempFile {})?;
+
+        Ok(write_path.as_ref())
+    }
+
+    // persist file to destination
+    fn finalize(&mut self) -> Result<()> {
+        let temp_file = self.temp_file.take().context(error::MissingTempFile {})?;
+
+        let path = self.as_ref();
+        temp_file
+            .into_temp_path()
+            .persist(&path)
+            .context(error::PersistTempFile { path })?;
+
+        Ok(())
+    }
+}
+
 /// Potential errors while downloading a snapshot and writing to a local file.
 mod error {
     use snafu::Snafu;
@@ -564,158 +717,5 @@ mod error {
             target: String,
             source: std::num::TryFromIntError,
         },
-    }
-}
-
-/// Shared interface for write targets.
-#[async_trait]
-trait SnapshotWriteTarget: AsRef<Path> {
-    // grow the target to the desired length
-    async fn grow(&mut self, length: i64) -> Result<()>;
-
-    // returns the file path to which blocks must be written
-    fn write_path(&self) -> Result<&Path>;
-
-    // persist the contents to disk
-    fn finalize(&mut self) -> Result<()>;
-}
-
-/// Implements file operations for block devices.
-struct BlockDeviceTarget {
-    path: PathBuf,
-}
-
-impl BlockDeviceTarget {
-    fn new_target<P: AsRef<Path>>(path: P) -> Result<Box<dyn SnapshotWriteTarget>> {
-        let path = path.as_ref();
-        Ok(Box::new(BlockDeviceTarget { path: path.into() }))
-    }
-
-    async fn is_valid<P: AsRef<Path>>(path: P) -> Result<bool> {
-        let path = path.as_ref();
-        if !path.exists() {
-            return Ok(false);
-        }
-
-        let file_meta = fs::metadata(path)
-            .await
-            .context(error::ReadFileMetadata { path })?;
-
-        if file_meta.file_type().is_block_device() {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-}
-
-impl AsRef<Path> for BlockDeviceTarget {
-    fn as_ref(&self) -> &Path {
-        self.path.as_ref()
-    }
-}
-
-#[async_trait]
-impl SnapshotWriteTarget for BlockDeviceTarget {
-    // ensures existing size >= length, but otherwise leaves untouched
-    async fn grow(&mut self, length: i64) -> Result<()> {
-        let path = self.as_ref();
-        let block_device_size = get_block_device_size(path).context(error::GetBlockDeviceSize)?;
-
-        // Make sure the block device is big enough to hold the snapshot
-        ensure!(
-            block_device_size >= length,
-            error::BlockDeviceTooSmall {
-                block_device_size: block_device_size / GIBIBYTE,
-                needed: length / GIBIBYTE,
-            }
-        );
-
-        Ok(())
-    }
-
-    // returns the file path to which blocks must be written
-    fn write_path(&self) -> Result<&Path> {
-        Ok(self.as_ref())
-    }
-
-    // no-op
-    fn finalize(&mut self) -> Result<()> {
-        Ok(())
-    }
-}
-
-/// Implements file operations for filesystem files.
-struct FileTarget {
-    path: PathBuf,
-    temp_file: Option<NamedTempFile>,
-}
-
-impl FileTarget {
-    fn new_target<P: AsRef<Path>>(path: P) -> Result<Box<dyn SnapshotWriteTarget>> {
-        let path = path.as_ref();
-        Ok(Box::new(FileTarget {
-            path: path.into(),
-            temp_file: None,
-        }))
-    }
-}
-
-impl AsRef<Path> for FileTarget {
-    fn as_ref(&self) -> &Path {
-        self.path.as_ref()
-    }
-}
-
-#[async_trait]
-impl SnapshotWriteTarget for FileTarget {
-    // truncate file to desired size
-    async fn grow(&mut self, length: i64) -> Result<()> {
-        let path = self.as_ref();
-
-        // Create a temporary file and extend it to the required size.
-        let target_dir = path
-            .parent()
-            .context(error::ValidateParentDirectory { path })?;
-
-        let temp_file = NamedTempFile::new_in(target_dir)
-            .context(error::CreateTempFile { path: target_dir })?;
-
-        let temp_file_len = length;
-        let temp_file_len = u64::try_from(temp_file_len).with_context(|| error::ConvertNumber {
-            what: "temp file length",
-            number: temp_file_len.to_string(),
-            target: "u64",
-        })?;
-
-        temp_file
-            .as_file()
-            .set_len(temp_file_len)
-            .context(error::ExtendTempFile {
-                path: temp_file.as_ref(),
-            })?;
-
-        self.temp_file.replace(temp_file);
-
-        Ok(())
-    }
-
-    fn write_path(&self) -> Result<&Path> {
-        let write_path = self.temp_file.as_ref().context(error::MissingTempFile {})?;
-
-        Ok(write_path.as_ref())
-    }
-
-    // persist file to destination
-    fn finalize(&mut self) -> Result<()> {
-        let temp_file = self.temp_file.take().context(error::MissingTempFile {})?;
-
-        let path = self.as_ref();
-        temp_file
-            .into_temp_path()
-            .persist(&path)
-            .context(error::PersistTempFile { path })?;
-
-        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ waiter.wait_for_completed("snap-1234")
 ```
 */
 
+mod block_device;
 mod download;
 mod upload;
 mod wait;


### PR DESCRIPTION
*Issue #, if available:*
Fixes #84, fixes #81.

*Description of changes:*
Add support for uploading from a block device.

Refactored `download.rs` a little:
* moved error mod to the end
* removed the `AsRef<Path>` trait bounds and impls on targets
* added the path to the error message for `GetBlockDeviceSize`

The individual commits may be easier to follow than the full diff; note that the "move error mod" change did not include any other changes.

*Testing done:*
Uploaded a snapshot from a block device, and downloaded the snapshot to that block device. Verified that the SHA-1 hashes matched.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
