### PR TITLE
Update license check job on runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,5 +38,5 @@ jobs:
     - run: cargo build --features ${{ matrix.features }} ${{ matrix.additional_flags }} --locked
     - run: cargo clippy --features ${{ matrix.features }} ${{ matrix.additional_flags }} --locked -- -D warnings --no-deps
     - run: cargo fmt -- --check
-    - run: cargo install --version 0.6.2 cargo-deny --no-default-features --locked
-    - run: cargo deny check --disable-fetch licenses
+    - run: cargo install --version 0.9.1 cargo-deny --locked
+    - run: cargo deny --features ${{ matrix.features }} --no-default-features check --disable-fetch licenses bans sources

--- a/deny.toml
+++ b/deny.toml
@@ -35,3 +35,13 @@ expression = "ISC"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
 ]
+
+[bans]
+# Deny multiple versions or wildcard dependencies.
+multiple-versions = "deny"
+wildcards = "deny"
+
+[sources]
+# Deny crates from unknown registries or git repositories.
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
*Description of changes:*

Bumps `cargo-deny` from 0.6.2 to 0.9.1 while also checking for:
- multiple versions
- wildcard dependencies
- unknown registries
- unknown git repositories

The license check was also tweaked to look at each feature individually.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
