### PR TITLE
Unpin tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rusoto-rustls = ["rusoto_core/rustls", "rusoto_ebs/rustls", "rusoto_ec2/rustls"]
 
 [dependencies]
 argh = "0.1.7"
-tokio = { version = "~1.8", features = ["fs", "io-util", "time"] }  # LTS
+tokio = { version = "1.8", features = ["fs", "io-util", "time"] }
 sha2 = "0.10.2"
 bytes = "1"
 base64 = "0.13.0"

--- a/src/download.rs
+++ b/src/download.rs
@@ -202,7 +202,7 @@ impl SnapshotDownloader {
                 .block_size
                 .context(error::FindBlockSizeSnafu { snapshot_id })?;
 
-            for block in response.blocks.unwrap_or_else(Vec::new).iter() {
+            for block in response.blocks.unwrap_or_default().iter() {
                 let index = block
                     .block_index
                     .context(error::FindBlockIndexSnafu { snapshot_id })?;


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

I ran into some issues when attempting to update some Bottlerocket Rust dependencies (in the tools workspace). Generally speaking, we should not lock a dependency minor version in a library that is to be consumed by other projects. Doing so can cause unresolvable build issues if a customer's dependencies lock to a different minor version.

No versions were changed in Cargo.lock in this PR, we just changing Cargo.toml to allow cargo to do its thing when others are using the library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
