### PR TITLE
Limit nix features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,15 +642,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
-name = "memoffset"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,7 +690,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sha2 = "0.10.2"
 bytes = "1"
 base64 = "0.13.0"
 futures = "0.3.21"
-nix = "0.24.1"
+nix = { version = "0.24.1", default-features = false, features = ["ioctl"] }
 rusoto_core = { version = "0.48.0", default-features = false }
 rusoto_credential = "0.48.0"
 rusoto_ebs = { version = "0.48.0", default-features = false }


### PR DESCRIPTION
This removes memoffset as an indirect dependency, and slightly reduces build times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
