### PR TITLE
Ignore AWS SDK for Rust and smithy-rs in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # For AWS SDK for Rust, ignore all (but one) updates
+      # - dependency-name: "aws-config"
+      - dependency-name: "aws-endpoint"
+      - dependency-name: "aws-http"
+      - dependency-name: "aws-hyper"
+      - dependency-name: "aws-sig*"
+      - dependency-name: "aws-sdk*"
+      - dependency-name: "aws-smithy*"
+      - dependency-name: "aws-types"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,11 +5,13 @@ on:
     branches: [develop]
     paths-ignore:
       - '**.md'
+      - '.github/dependabot.yml'
   # triggers when a PR is merged
   push:
     branches: [develop]
     paths-ignore:
       - '**.md'
+      - '.github/dependabot.yml'
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Since these dependencies need to be updated in unison, we'll take care of them manually.
`aws-config` was left commented out to provide a single notification that an update has occurred.

Also ignores triggering GitHub Actions when making future changes to `dependabot.yml`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
