### PR TITLE
Fix the wrong type i32 used for offset calculation at download to u64

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -341,12 +341,20 @@ impl SnapshotDownloader {
             .await
             .context(error::OpenFileSnafu { path })?;
 
-        let offset = context.block_index * block_size;
-        let offset = u64::try_from(offset).with_context(|_| error::ConvertNumberSnafu {
-            what: "file offset",
-            number: offset.to_string(),
-            target: "u64",
-        })?;
+        // Calculate the offset to write the block into the target file
+        let block_index_u64 =
+            u64::try_from(context.block_index).with_context(|_| error::ConvertNumberSnafu {
+                what: "block index",
+                number: context.block_index.to_string(),
+                target: "u64",
+            })?;
+        let block_size_u64 =
+            u64::try_from(block_size).with_context(|_| error::ConvertNumberSnafu {
+                what: "block size",
+                number: block_size.to_string(),
+                target: "u64",
+            })?;
+        let offset = block_index_u64 * block_size_u64;
 
         f.seek(SeekFrom::Start(offset))
             .await


### PR DESCRIPTION
The offset calculation for writing a block to download target file is
in i32 after commit 118e5861, which replaced the AWS SDK from rusoto
to AWS's one and also replaced the type of block indext and block size.
This causes an integer overflow when there is a block whoes index is
greater than 4096 or the offset is greater than 2 GiB as the block size
is 512 KiB.

This commit will change the type casting of the offset to type castings
of block indext and block size to prevent integer overflows at offset
calculations for downloads.

Issue: #185