### PR TITLE
Prepare for v0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2022-10-03
+### Changed
+- Update dependencies [#197]
+
 ## [0.4.1] - 2022-08-12
 ### Changed
 - Prevent integer overflows during offset calculations ([#186], thanks @okudajun!)
@@ -50,7 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/coldsnap/compare/v0.4.1...develop
+[Unreleased]: https://github.com/awslabs/coldsnap/compare/v0.4.2...develop
+[0.4.2]: https://github.com/awslabs/coldsnap/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/awslabs/coldsnap/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/awslabs/coldsnap/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/awslabs/coldsnap/compare/v0.3.2...v0.3.3
@@ -120,4 +125,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#171]: https://github.com/awslabs/coldsnap/pull/171
 [#179]: https://github.com/awslabs/coldsnap/pull/179
 [#186]: https://github.com/awslabs/coldsnap/pull/186
+[#197]: https://github.com/awslabs/coldsnap/pull/197
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "coldsnap"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "argh",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coldsnap"
-version = "0.4.1"
+version = "0.4.2"
 description = "A library and command-line interface for uploading and downloading Amazon EBS snapshots"
 authors = ["Ben Cressey <bcressey@amazon.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
*Description of changes:*

Prepare for 0.4.2 release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
