### PR TITLE
Bump rust to 1.66.1 and cargo-deny to 0.13.5 in actions runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,12 +36,12 @@ jobs:
           key: ${{ hashFiles('.github/cache_bust') }}-${{ hashFiles('.github/workflows/rust.yml') }}-${{ runner.os }}-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ hashFiles('.github/cache_bust') }}-${{ hashFiles('.github/workflows/rust.yml') }}-${{ runner.os }}-${{ matrix.features }}
-      - run: rustup default 1.64.0
+      - run: rustup default 1.66.1
       - run: rustup component add rustfmt
       - run: rustup component add clippy
       - run: cargo test --features ${{ matrix.features }} ${{ matrix.additional_flags }} --locked
       - run: cargo build --features ${{ matrix.features }} ${{ matrix.additional_flags }} --locked
       - run: cargo clippy --features ${{ matrix.features }} ${{ matrix.additional_flags }} --locked -- -D warnings --no-deps
       - run: cargo fmt -- --check
-      - run: cargo install --version 0.12.2 cargo-deny --locked
+      - run: cargo install --version 0.13.5 cargo-deny --locked
       - run: cargo deny --features ${{ matrix.features }} --no-default-features check --disable-fetch licenses bans sources

--- a/src/download.rs
+++ b/src/download.rs
@@ -163,10 +163,7 @@ impl SnapshotDownloader {
             .expect("poisoned");
         let block_errors_count = block_errors.keys().len();
         if block_errors_count != 0 {
-            let error_report: String = block_errors
-                .iter()
-                .map(|(_, e)| format!("\n{}", e))
-                .collect();
+            let error_report: String = block_errors.values().map(|e| e.to_string()).collect();
             error::GetSnapshotBlocksSnafu {
                 error_count: block_errors_count,
                 snapshot_id: snapshot.snapshot_id,
@@ -320,7 +317,7 @@ impl SnapshotDownloader {
         let mut block_digest = Sha256::new();
         block_digest.update(&block_data);
         let hash_bytes = block_digest.finalize();
-        let block_hash = base64::encode(&hash_bytes);
+        let block_hash = base64::encode(hash_bytes);
 
         ensure!(
             block_hash == expected_hash,

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -207,10 +207,7 @@ impl SnapshotUploader {
             .expect("poisoned");
         let block_errors_count = block_errors.keys().len();
         if block_errors_count != 0 {
-            let error_report: String = block_errors
-                .iter()
-                .map(|(_, e)| format!("\n{}", e))
-                .collect();
+            let error_report: String = block_errors.values().map(|e| e.to_string()).collect();
             error::PutSnapshotBlocksSnafu {
                 error_count: block_errors_count,
                 snapshot_id: snapshot_id.clone(),
@@ -365,7 +362,7 @@ impl SnapshotUploader {
         let mut block_digest = Sha256::new();
         block_digest.update(&block);
         let hash_bytes = block_digest.finalize();
-        let block_hash = base64::encode(&hash_bytes);
+        let block_hash = base64::encode(hash_bytes);
 
         let snapshot_id = &context.snapshot_id;
         let block_index = context.block_index;


### PR DESCRIPTION
**Description of changes:**

Bumps the rust toolchain to 1.66.1 and `cargo-deny` to 0.13.5 in actions runner

Also addressed new `clippy` warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
