### PR TITLE
Prepare for v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.3] - 2023-03-02
+## [0.5.0] - 2023-03-08
 ### Changed
 - Add debug logging to help with troubleshooting [#220]
 - Remove minor/patch versions from Cargo.tomls [#237]
 - Update dependencies
+
+## ~~[0.4.3] - 2023-03-02~~
+### ~~Changed~~
+- ~~Add debug logging to help with troubleshooting [#220]~~
+- ~~Remove minor/patch versions from Cargo.tomls [#237]~~
+- ~~Update dependencies~~
+
+⚠ This release was yanked and re-released as 0.5.0 due to breaking changes.
 
 ## [0.4.2] - 2022-10-03
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "coldsnap"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "argh",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coldsnap"
-version = "0.4.3"
+version = "0.5.0"
 description = "A library and command-line interface for uploading and downloading Amazon EBS snapshots"
 authors = ["Ben Cressey <bcressey@amazon.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
*Issue #, if available:*

#242

*Description of changes:*

This release is identical to the previous v0.4.3, but will be re-released as v0.5.0 due to a breaking change in the updated dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
