### PR TITLE
Fine-tune the Ordering for changed_blocks_count

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -218,7 +218,7 @@ impl SnapshotUploader {
             .fail()?;
         }
 
-        let changed_blocks_count = changed_blocks_count.load(AtomicOrdering::SeqCst);
+        let changed_blocks_count = changed_blocks_count.load(AtomicOrdering::Relaxed);
 
         // Compute the "linear" hash - the hash of all hashes in block index order.
         let block_digests = Arc::try_unwrap(block_digests)
@@ -397,7 +397,7 @@ impl SnapshotUploader {
         block_digests.insert(block_index, hash_bytes.to_vec());
 
         let changed_blocks_count = &context.changed_blocks_count;
-        changed_blocks_count.fetch_add(1, AtomicOrdering::SeqCst);
+        changed_blocks_count.fetch_add(1, AtomicOrdering::Relaxed);
 
         if let Some(ref progress_bar) = *context.progress_bar {
             progress_bar.inc(1);


### PR DESCRIPTION
https://github.com/awslabs/coldsnap/blob/a60762c53f5ba3e8a0b6fa3d972ec082739f33df/src/upload.rs#L221
https://github.com/awslabs/coldsnap/blob/a60762c53f5ba3e8a0b6fa3d972ec082739f33df/src/upload.rs#L400
Here `changed_blocks_count` is employed solely for counting purposes, rather than for synchronizing access to other shared variables. While `SeqCst` guarantees program correctness, it can also impact performance. Therefore, using `Relaxed` is sufficient to maintain the program's correctness without adversely affecting its efficiency.