### PR TITLE
Print stable Rust version in actions runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,8 @@ jobs:
           key: ${{ hashFiles('.github/cache_bust') }}-${{ hashFiles('.github/workflows/rust.yml') }}-${{ runner.os }}-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ hashFiles('.github/cache_bust') }}-${{ hashFiles('.github/workflows/rust.yml') }}-${{ runner.os }}-${{ matrix.features }}
-      - run: rustup default
+      # print the current rustc. replace stable to pin to a specific toolchain version.
+      - run: rustup default stable
       - run: rustup component add rustfmt
       - run: rustup component add clippy
       - run: cargo test --features ${{ matrix.features }} ${{ matrix.additional_flags }} --locked


### PR DESCRIPTION
*Description of changes:*

Rather than removing the pin entirely, if set to `default stable` the actions runner will give us useful details about the toolchain.

*Example output:*
```shell
info: using existing install for 'stable-x86_64-unknown-linux-gnu'
info: default toolchain set to 'stable-x86_64-unknown-linux-gnu'

  stable-x86_64-unknown-linux-gnu unchanged - rustc 1.80.0 (051478957 2024-07-21)

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
