### PR TITLE
Allow users to provide tags on upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Alternately, you can use `coldsnap wait`, which offers more flexibility in terms
 $ coldsnap wait snap-1234
 ```
 
+If you want to add tags to the uploaded snapshot, add `--tag Key=k,Value=v` for each desired tag:
+
+```
+$ coldsnap upload snap-1234 --tag "Key=MyKeyName,Value=MyKeyValue" --tag "Key=MyOtherKeyName,Value=MyOtherKeyValue"
+```
+
+
 ### Download
 
 Download an EBS snapshot into a local file:

--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -8,6 +8,7 @@ snapshots.
 
 use argh::FromArgs;
 use aws_sdk_ebs::Client as EbsClient;
+use aws_sdk_ebs::types::Tag;
 use aws_sdk_ec2::Client as Ec2Client;
 use aws_types::region::Region;
 use aws_types::SdkConfig;
@@ -94,6 +95,7 @@ async fn run() -> Result<()> {
                     &upload_args.file,
                     upload_args.volume_size,
                     upload_args.description.as_deref(),
+                    Some(upload_args.tag),
                     progress_bar?,
                 )
                 .await
@@ -266,6 +268,27 @@ struct DownloadArgs {
     no_progress: bool,
 }
 
+
+/// Turn a user-specified tag string into a Tag object. Tags must start with 'KEY=' and
+/// denote the tag value with ',Value='.
+fn tag_from_str(input: &str) -> std::result::Result<Tag, String> {
+    const KEY_DELIMITER: &str = "Key=";
+    const VALUE_DELIMITER: &str = ",Value=";
+
+    if !input.starts_with(KEY_DELIMITER) {
+        return Err(format!("Tag inputs must start with '{KEY_DELIMITER}'").to_string());
+    }
+
+    if !input.contains(VALUE_DELIMITER) {
+        return Err(format!("Tag inputs must contain value entry with '{VALUE_DELIMITER}'").to_string());
+    }
+
+    //We have already validated the input contains both delimeters so there is no panic risk for unwrapping directly.
+    let k_v: (&str, &str) = input.split_once(KEY_DELIMITER).unwrap().1.split_once(VALUE_DELIMITER).unwrap();
+
+    Ok(Tag::builder().key(k_v.0).value(k_v.1).build())
+}
+
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "upload")]
 /// Upload a local file into an EBS snapshot.
@@ -280,6 +303,10 @@ struct UploadArgs {
     #[argh(option)]
     /// the description for the snapshot
     description: Option<String>,
+
+    #[argh(option, from_str_fn(tag_from_str))]
+    /// a tag for the snapshot
+    tag: Vec<Tag>,
 
     #[argh(switch)]
     /// disable the progress bar

--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -7,8 +7,8 @@ snapshots.
 */
 
 use argh::FromArgs;
-use aws_sdk_ebs::Client as EbsClient;
 use aws_sdk_ebs::types::Tag;
+use aws_sdk_ebs::Client as EbsClient;
 use aws_sdk_ec2::Client as Ec2Client;
 use aws_types::region::Region;
 use aws_types::SdkConfig;
@@ -268,7 +268,6 @@ struct DownloadArgs {
     no_progress: bool,
 }
 
-
 /// Turn a user-specified tag string into a Tag object. Tags must start with 'KEY=' and
 /// denote the tag value with ',Value='.
 fn tag_from_str(input: &str) -> std::result::Result<Tag, String> {
@@ -280,13 +279,55 @@ fn tag_from_str(input: &str) -> std::result::Result<Tag, String> {
     }
 
     if !input.contains(VALUE_DELIMITER) {
-        return Err(format!("Tag inputs must contain value entry with '{VALUE_DELIMITER}'").to_string());
+        return Err(
+            format!("Tag inputs must contain value entry with '{VALUE_DELIMITER}'").to_string(),
+        );
     }
 
-    //We have already validated the input contains both delimeters so there is no panic risk for unwrapping directly.
-    let k_v: (&str, &str) = input.split_once(KEY_DELIMITER).unwrap().1.split_once(VALUE_DELIMITER).unwrap();
+    //We have already validated the input contains both delimiters so there is no panic risk for unwrapping directly.
+    let (key, val) = input
+        .split_once(KEY_DELIMITER)
+        .unwrap()
+        .1
+        .split_once(VALUE_DELIMITER)
+        .unwrap();
 
-    Ok(Tag::builder().key(k_v.0).value(k_v.1).build())
+    if key.is_empty() {
+        return Err("Tag inputs must contain a non-empty key entry".to_string());
+    }
+    Ok(Tag::builder().key(key).value(val).build())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn valid_tag_inputs() {
+        for input in [
+            "Key=A,Value=",
+            "Key=A,Value=B",
+            "Key=A C,Value=D C",
+            "Key=Key=,Value=Value=",
+            "Key=A1+-=._:/@,,Value=B1+-=._:/@,",
+        ] {
+            assert!(tag_from_str(input).is_ok());
+        }
+    }
+
+    #[test]
+    fn invalid_tag_inputs() {
+        for input in [
+            "Key=A",
+            ",Value=B",
+            "Key=,Value=B",
+            "Kay=A,Value=B",
+            "Key=A,value=B",
+            "Kay=A,Key=A,Value=B",
+        ] {
+            assert!(tag_from_str(input).is_err());
+        }
+    }
 }
 
 #[derive(FromArgs, PartialEq, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ let client = EbsClient::new(&aws_config::from_env().region("us-west-2").load().a
 let uploader = SnapshotUploader::new(client);
 let path = Path::new("./disk.img");
 
-let snapshot_id = uploader.upload_from_file(&path, None, None, None)
+let snapshot_id = uploader.upload_from_file(&path, None, None, None, None)
         .await
         .expect("failed to upload snapshot");
 # }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -7,7 +7,7 @@ Upload Amazon EBS snapshots.
 
 use crate::block_device::get_block_device_size;
 use aws_sdk_ebs::primitives::ByteStream;
-use aws_sdk_ebs::types::{ChecksumAggregationMethod, ChecksumAlgorithm};
+use aws_sdk_ebs::types::{ChecksumAggregationMethod, ChecksumAlgorithm, Tag};
 use aws_sdk_ebs::Client as EbsClient;
 use base64::engine::general_purpose::STANDARD as base64_engine;
 use base64::Engine as _;
@@ -62,12 +62,15 @@ impl SnapshotUploader {
     ///   file's size will be rounded up to the nearest GiB and used instead.
     /// * `description` is the snapshot description. If no description is provided (`None`), the
     ///   source file's name will be used instead.
+    /// * 'tags' is the tags to add to the snapshot. If no tags are provided ('None'), then no
+    ///   tags are added.
     /// * `progress_bar` is optional, since output to the terminal may not be wanted.
     pub async fn upload_from_file<P: AsRef<Path>>(
         &self,
         path: P,
         volume_size: Option<i64>,
         description: Option<&str>,
+        tags: Option<Vec<Tag>>,
         progress_bar: Option<ProgressBar>,
     ) -> Result<String> {
         let path = path.as_ref();
@@ -103,7 +106,7 @@ impl SnapshotUploader {
 
         // Start the snapshot, which gives us the ID and block size we need.
         debug!("Uploading {}G to snapshot...", volume_size);
-        let (snapshot_id, block_size) = self.start_snapshot(volume_size, description).await?;
+        let (snapshot_id, block_size) = self.start_snapshot(volume_size, description, tags).await?;
         let file_blocks = (file_size + i64::from(block_size - 1)) / i64::from(block_size);
         let file_blocks =
             i32::try_from(file_blocks).with_context(|_| error::ConvertNumberSnafu {
@@ -251,12 +254,13 @@ impl SnapshotUploader {
     }
 
     /// Start a new snapshot and return the ID and block size for subsequent puts.
-    async fn start_snapshot(&self, volume_size: i64, description: String) -> Result<(String, i32)> {
+    async fn start_snapshot(&self, volume_size: i64, description: String, tags: Option<Vec<Tag>>) -> Result<(String, i32)> {
         let start_response = self
             .ebs_client
             .start_snapshot()
             .volume_size(volume_size)
             .set_description(Some(description))
+            .set_tags(tags)
             .set_timeout(Some(SNAPSHOT_TIMEOUT_MINUTES))
             .send()
             .await

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -254,7 +254,12 @@ impl SnapshotUploader {
     }
 
     /// Start a new snapshot and return the ID and block size for subsequent puts.
-    async fn start_snapshot(&self, volume_size: i64, description: String, tags: Option<Vec<Tag>>) -> Result<(String, i32)> {
+    async fn start_snapshot(
+        &self,
+        volume_size: i64,
+        description: String,
+        tags: Option<Vec<Tag>>,
+    ) -> Result<(String, i32)> {
         let start_response = self
             .ebs_client
             .start_snapshot()


### PR DESCRIPTION
Closes: #172 

*Description of changes:*

This change adds the ability for users to pass in any number of tags during upload. The tags are passed as given to EBS start-snapshot. Tags are expected to be inputted as "Key=k,Value=v" where k and v are users desired tags. The key and value delimiters were chosen to adhere as much as possible to other AWS cli tag inputs. Any restrictions on tags are expected to be handled by the underlining EBS apis.

# Testing

local testing performed with the following commands and validation of upload and metadata when expected using ```aws ec2 describe-snapshots --snapshot-id <<ID>>```. I have removed fields from the describe commands that aren't useful for the validation of tags.

## No tags provided
	$ cargo run upload /tmp/coldsnapTestAMI.bin 
		
```
{
    "Snapshots": [
        {
            "SnapshotId": "snap-0d6c225070eded508",
            "State": "completed",
            "Progress": "100%",
            "Description": "coldsnapTestAMI.bin",
        }
    ]
}
```
----
	$ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: no tags"
```
{
    "Snapshots": [
        {
            "SnapshotId": "snap-033a94351b0f601c1",
            "VolumeId": "vol-ffffffff",
            "State": "completed",
            "Progress": "100%",
            "Description": "Test coldsnap tags: no tags",
        }
    ]
}
```

## Single tag provided:
    
    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: single happy tag" --tag "Key=Test,Value=Hello"
```
{
    "Snapshots": [
        {
            "Tags": [
                {
                    "Key": "Test",
                    "Value": "Hello"
                }
            ],
            "SnapshotId": "snap-00b163873d33fd695",
            "VolumeId": "vol-ffffffff",
            "State": "completed",
            "Progress": "100%",
            "Description": "Test coldsnap tags: single happy tag",
        }
    ]
}
```

---

    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: special characters" --tag "Key=Test1+-=._:/@,,Value=Hello"
```
{
    "Snapshots": [
        {
            "Tags": [
                {
                    "Key": "Test1+-=._:/@,",
                    "Value": "Hello"
                }
            ],
            "SnapshotId": "snap-0ebd0652b188d5ad0",
            "VolumeId": "vol-ffffffff",
            "State": "completed",
            "Progress": "100%",
            "Description": "Test coldsnap tags: special characters",
        }
    ]
}
```

---


    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: empty value" --tag "Key=Test,Value= "
```
{
    "Snapshots": [
        {
            "Tags": [
                {
                    "Key": "Test",
                    "Value": " "
                }
            ],
            "SnapshotId": "snap-04acbc91193f94484",
            "VolumeId": "vol-ffffffff",
            "State": "completed",
            "Progress": "100%",
            "Description": "Test coldsnap tags: empty value",
        }
    ]
}
```    

----

    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: key with space" --tag "Key=Test with space,Value=Hello"
```
{
    "Snapshots": [
        {
            "Tags": [
                {
                    "Key": "Test with space",
                    "Value": "Hello"
                }
            ],
            "SnapshotId": "snap-0a4b1d6557c23eb93",
            "VolumeId": "vol-ffffffff",
            "State": "completed",
            "Progress": "100%",
            "Description": "Test coldsnap tags: key with space",
        }
    ]
}
```    

----

    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: Key= and Value= parsing allows themselves for input" --tag "Key=Key=,Value=,Value="
```
{
    "Snapshots": [
        {
            "Tags": [
                {
                    "Key": "Key=",
                    "Value": ",Value="
                }
            ],
            "SnapshotId": "snap-0f8312c736d941007",
            "VolumeId": "vol-ffffffff",
            "State": "completed",
            "Progress": "100%",
            "Description": "Test coldsnap tags: Key= and Value= parsing allows themselves for input",
        }
    ]
}
```


## Multiple tags provided:
    
    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: multiple happy tags" --tag "Key=Test,Value=Hello" --tag "Key=Test2,Value=Hello2"
```
{
    "Snapshots": [
        {
            "Tags": [
                {
                    "Key": "Test",
                    "Value": "Hello"
                },
                {
                    "Key": "Test2",
                    "Value": "Hello2"
                }
            ],
            "SnapshotId": "snap-037581676b4e505a6",
            "VolumeId": "vol-ffffffff",
            "State": "completed",
            "Progress": "100%",
            "Description": "Test coldsnap tags: multiple happy tags",
        }
    ]
}
```

----

    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: case sensitive keys are unique" --tag "Key=Test,Value=Hello" --tag "Key=test,Value=Hello2"
```
{
    "Snapshots": [
        {
            "Tags": [
                {
                    "Key": "test",
                    "Value": "Hello2"
                },
                {
                    "Key": "Test",
                    "Value": "Hello"
                }
            ],
            "SnapshotId": "snap-01a853dec4ae8e16f",
            "VolumeId": "vol-ffffffff",
            "State": "completed",
            "Progress": "100%",
            "Description": "Test coldsnap tags: case sensitive keys are unique",
        }
    ]
}
```

## Expected failure modes:
    
    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: tag key over 127 characters" --tag "Key=.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-,Value=Hello"
```
Failed to upload snapshot: Failed to start snapshot: service error: ValidationException: 1 validation error detected: Value '.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-' at 'tags.1.member.key' failed to satisfy constraint: Member must have length less than or equal to 127: ValidationException: 1 validation error detected: Value '.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-' at 'tags.1.member.key' failed to satisfy constraint: Member must have length less than or equal to 127
```    

----

    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: tag value over 255 characters" --tag "Key=Test,Value=.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-"
```
Failed to upload snapshot: Failed to start snapshot: service error: ValidationException: 1 validation error detected: Value '.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-' at 'tags.1.member.value' failed to satisfy constraint: Member must have length less than or equal to 255: ValidationException: 1 validation error detected: Value '.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-.A_,C/,=-=_1BB@ c,,bcC ,+a--3_.c._. -1C-.c3@@aa./C C-/A:B_B+13A= :a@@bbCA .-BC =C2b_-@,3@@3aC.A+ C=a,/ a/b1c+11/a+21C@c._AA133a-' at 'tags.1.member.value' failed to satisfy constraint: Member must have length less than or equal to 255
```

----

    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: duplicate key " --tag "Key=Test,Value=Hello" --tag "Key=Test,Value=Hello"    
```
Failed to upload snapshot: Failed to start snapshot: service error: ValidationException: Duplicate tag key 'Test' specified.: ValidationException: Duplicate tag key 'Test' specified.
```

----

    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: tag is empty string" --tag ""
```
Error parsing option '--tag' with value '': Tag inputs must start with 'Key='

Run coldsnap --help for more information.
```

----

    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: tag doesn't contain ',Value='" --tag "Key=TestValue=Hello"
```
Error parsing option '--tag' with value 'Key=TestValue=Hello': Tag inputs must contain value entry with ',Value='

Run coldsnap --help for more information.
```

----

    $ cargo run upload /tmp/coldsnapTestAMI.bin --description "Test coldsnap tags: tag doesn't start with 'Key='" --tag "FailKey=Test,Value=Hello"
```
Error parsing option '--tag' with value 'FailKey=Test,Value=Hello': Tag inputs must start with 'Key='

Run coldsnap --help for more information.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
