### PR TITLE
Turn "omit zero blocks" off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ If you want to add tags to the uploaded snapshot, add `--tag Key=k,Value=v` for 
 $ coldsnap upload snap-1234 --tag "Key=MyKeyName,Value=MyKeyValue" --tag "Key=MyOtherKeyName,Value=MyOtherKeyValue"
 ```
 
+If you want to omit blocks of all zeroes when uploading a snapshot, add `--omit-zero-blocks`.
+This was the historical behavior, but is usually incompatible with encrypted EBS snapshots.
+Applications that write zeroes to blocks will expect to read zeroes back, and for that to work, the blocks must be present in the snapshot.
+If unsure, avoid using this option.
+
+```
+$ coldsnap upload disk.img --omit-zero-blocks
+```
 
 ### Download
 

--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -12,7 +12,9 @@ use aws_sdk_ebs::Client as EbsClient;
 use aws_sdk_ec2::Client as Ec2Client;
 use aws_types::region::Region;
 use aws_types::SdkConfig;
-use coldsnap::{SnapshotDownloader, SnapshotUploader, SnapshotWaiter, WaitParams};
+use coldsnap::{
+    SnapshotDownloader, SnapshotUploader, SnapshotWaiter, UploadZeroBlocks, WaitParams,
+};
 use env_logger::{Builder, Env};
 use indicatif::{ProgressBar, ProgressStyle};
 use log::{debug, LevelFilter};
@@ -89,6 +91,10 @@ async fn run() -> Result<()> {
             );
 
             let progress_bar = build_progress_bar(upload_args.no_progress, "Uploading");
+            let zero_blocks = upload_args
+                .omit_zero_blocks
+                .then_some(UploadZeroBlocks::Omit);
+
             debug!("Uploading {}", upload_args.file.display());
             let snapshot_id = uploader
                 .upload_from_file(
@@ -97,6 +103,7 @@ async fn run() -> Result<()> {
                     upload_args.description.as_deref(),
                     Some(upload_args.tag),
                     progress_bar?,
+                    zero_blocks,
                 )
                 .await
                 .context(error::UploadSnapshotSnafu)?;
@@ -356,6 +363,10 @@ struct UploadArgs {
     #[argh(switch)]
     /// wait for snapshot to be in "completed" state
     wait: bool,
+
+    #[argh(switch)]
+    /// omit blocks of all zeros when uploading
+    omit_zero_blocks: bool,
 }
 
 /// Turn a user-specified duration in seconds into a Duration object, for argh parsing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ let client = EbsClient::new(&aws_config::from_env().region("us-west-2").load().a
 let uploader = SnapshotUploader::new(client);
 let path = Path::new("./disk.img");
 
-let snapshot_id = uploader.upload_from_file(&path, None, None, None, None)
+let snapshot_id = uploader.upload_from_file(&path, None, None, None, None, None)
         .await
         .expect("failed to upload snapshot");
 # }
@@ -66,6 +66,7 @@ pub use download::SnapshotDownloader;
 
 pub use upload::Error as UploadError;
 pub use upload::SnapshotUploader;
+pub use upload::ZeroBlocks as UploadZeroBlocks;
 
 pub use wait::Error as WaitError;
 pub use wait::{SnapshotWaiter, WaitParams};

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -47,6 +47,12 @@ const SHA256_ALGORITHM: ChecksumAlgorithm = ChecksumAlgorithm::ChecksumAlgorithm
 const LINEAR_METHOD: ChecksumAggregationMethod =
     ChecksumAggregationMethod::ChecksumAggregationLinear;
 
+#[derive(Clone)]
+pub enum ZeroBlocks {
+    Include,
+    Omit,
+}
+
 pub struct SnapshotUploader {
     ebs_client: EbsClient,
 }
@@ -72,6 +78,7 @@ impl SnapshotUploader {
         description: Option<&str>,
         tags: Option<Vec<Tag>>,
         progress_bar: Option<ProgressBar>,
+        zero_blocks: Option<ZeroBlocks>,
     ) -> Result<String> {
         let path = path.as_ref();
         let description = description.map(|s| s.to_string()).unwrap_or_else(|| {
@@ -141,6 +148,8 @@ impl SnapshotUploader {
             None => Arc::new(None),
         };
 
+        let zero_blocks = zero_blocks.unwrap_or(ZeroBlocks::Include);
+
         // Create a context for each block that can be moved to another thread.
         let mut block_contexts = Vec::new();
         let mut remaining_data = file_size;
@@ -167,6 +176,7 @@ impl SnapshotUploader {
                 block_errors: Arc::clone(&block_errors),
                 progress_bar: Arc::clone(&progress_bar),
                 ebs_client: self.ebs_client.clone(),
+                zero_blocks: zero_blocks.clone(),
             });
 
             remaining_data -= i64::from(block_size);
@@ -356,13 +366,15 @@ impl SnapshotUploader {
                 offset,
             })?;
 
-        // Blocks of all zeroes should be omitted from the snapshot.
-        let sparse = block.iter().all(|&byte| byte == 0u8);
-        if sparse {
-            if let Some(ref progress_bar) = *context.progress_bar {
-                progress_bar.inc(1);
+        if let ZeroBlocks::Omit = context.zero_blocks {
+            let sparse = block.iter().all(|&byte| byte == 0u8);
+            // Found a block of all zeroes, and told to omit those from the snapshot.
+            if sparse {
+                if let Some(ref progress_bar) = *context.progress_bar {
+                    progress_bar.inc(1);
+                }
+                return Ok(());
             }
-            return Ok(());
         }
 
         // Blocks must be padded to the expected block size.
@@ -428,6 +440,7 @@ struct BlockContext {
     block_errors: Arc<Mutex<BTreeMap<i32, Error>>>,
     progress_bar: Arc<Option<ProgressBar>>,
     ebs_client: EbsClient,
+    zero_blocks: ZeroBlocks,
 }
 
 /// Potential errors while reading a local file and uploading a snapshot.

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -47,9 +47,14 @@ const SHA256_ALGORITHM: ChecksumAlgorithm = ChecksumAlgorithm::ChecksumAlgorithm
 const LINEAR_METHOD: ChecksumAggregationMethod =
     ChecksumAggregationMethod::ChecksumAggregationLinear;
 
-#[derive(Clone)]
+/// Specify how blocks of all zeroes should be handled.
+#[derive(Copy, Clone)]
 pub enum ZeroBlocks {
+    /// Include blocks of all zeroes in the snapshot.
     Include,
+    /// Omit blocks of all zeroes from the snapshot.
+    /// This is incompatible with encrypted snapshots if the application expects to read zeroes
+    /// from those blocks.
     Omit,
 }
 
@@ -71,6 +76,8 @@ impl SnapshotUploader {
     /// * 'tags' is the tags to add to the snapshot. If no tags are provided ('None'), then no
     ///   tags are added.
     /// * `progress_bar` is optional, since output to the terminal may not be wanted.
+    /// * `zero_blocks` specifies how zero blocks will be handled. If no value is provided
+    ///   (`None`), then all blocks will be uploaded.
     pub async fn upload_from_file<P: AsRef<Path>>(
         &self,
         path: P,
@@ -176,7 +183,7 @@ impl SnapshotUploader {
                 block_errors: Arc::clone(&block_errors),
                 progress_bar: Arc::clone(&progress_bar),
                 ebs_client: self.ebs_client.clone(),
-                zero_blocks: zero_blocks.clone(),
+                zero_blocks,
             });
 
             remaining_data -= i64::from(block_size);


### PR DESCRIPTION
**Issue #, if available:**
Fixes #395

**Description of changes:**
Include zero blocks by default while uploading snapshots, and provide an option to restore the old behavior for users that really know what they're doing. This is a breaking change.

**Testing done:**
Default, without `--omit-zero-blocks`:
```
❯ cargo run --release -- upload bottlerocket-aws-k8s-1.32-x86_64.img
    Finished `release` profile [optimized] target(s) in 0.11s
     Running `target/release/coldsnap --profile bcressey upload bottlerocket-aws-k8s-1.32-x86_64.img`
snap-06036d840efc49d68

❯ aws ebs list-snapshot-blocks --snapshot-id snap-06036d840efc49d68 | jq '.Blocks|length'
4096
```

With the new `--omit-zero-blocks` option:
```
❯ cargo run --release -- upload --omit-zero-blocks bottlerocket-aws-k8s-1.32-x86_64.img
    Finished `release` profile [optimized] target(s) in 2m 56s
     Running `target/release/coldsnap --profile bcressey upload --omit-zero-blocks bottlerocket-aws-k8s-1.32-x86_64.img`
snap-0f1a5a595f2d75837

❯ aws ebs list-snapshot-blocks --snapshot-id snap-0f1a5a595f2d75837 | jq '.Blocks|length'
1326
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
