### PR TITLE
add user agent to AWS API requests

### DIFF
--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -10,6 +10,7 @@ use argh::FromArgs;
 use aws_sdk_ebs::types::Tag;
 use aws_sdk_ebs::Client as EbsClient;
 use aws_sdk_ec2::Client as Ec2Client;
+use aws_types::app_name::AppName;
 use aws_types::region::Region;
 use aws_types::SdkConfig;
 use coldsnap::{SnapshotDownloader, SnapshotUploader, SnapshotWaiter, WaitParams};
@@ -198,7 +199,10 @@ async fn build_client_config(
         }
     };
 
-    config.load().await
+    let app_name =
+        AppName::new(format!("coldsnap-{}", env!("CARGO_PKG_VERSION"))).expect("valid app name");
+
+    config.app_name(app_name).load().await
 }
 
 /// Initializes the logger and sets logging level based on input.


### PR DESCRIPTION
**Issue #, if available:**
Fixes: #31 

**Description of changes:**
When using the coldsnap CLI, include a user-agent so that any defects in the implementation can be mapped back to this project.

This does not affect the library functions, since there the client is under the control of the caller.

**Testing done:**
Replaced the logging setup with:
```
tracing_subscriber::fmt::init();
```

Observed the user agent was set to the expected value:
```
 ("user-agent", "aws-sdk-rust/1.3.6 os/linux lang/rust/1.88.0"), ("x-amz-user-agent", "aws-sdk-rust/1.3.6 ua/2.1 api/ebs/1.64.0 os/linux lang/rust/1.88.0 m/E md/http#hyper-1.x app/coldsnap-0.8.0")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
