### PR TITLE
allow specifying the KMS key for snapshots on upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ If unsure, avoid using this option.
 $ coldsnap upload disk.img --omit-zero-blocks
 ```
 
+If you want to encrypt with a specific KMS key when uploading a snapshot, add `--kms-key-id` and the desired ARN.
+
+```
+$ coldsnap upload disk.img --kms-key-id arn:aws:kms:us-west-2:444455556666:key/1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d
+```
+
 ### Download
 
 Download an EBS snapshot into a local file:

--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -105,6 +105,7 @@ async fn run() -> Result<()> {
                     Some(upload_args.tag),
                     progress_bar?,
                     zero_blocks,
+                    upload_args.kms_key_id,
                 )
                 .await
                 .context(error::UploadSnapshotSnafu)?;
@@ -359,6 +360,10 @@ struct UploadArgs {
     #[argh(option, from_str_fn(tag_from_str))]
     /// a tag for the snapshot
     tag: Vec<Tag>,
+
+    #[argh(option)]
+    /// KMS key ARN to use for encryption.
+    kms_key_id: Option<String>,
 
     #[argh(switch)]
     /// disable the progress bar

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ let client = EbsClient::new(&aws_config::from_env().region("us-west-2").load().a
 let uploader = SnapshotUploader::new(client);
 let path = Path::new("./disk.img");
 
-let snapshot_id = uploader.upload_from_file(&path, None, None, None, None, None)
+let snapshot_id = uploader.upload_from_file(&path, None, None, None, None, None, None)
         .await
         .expect("failed to upload snapshot");
 # }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -78,6 +78,8 @@ impl SnapshotUploader {
     /// * `progress_bar` is optional, since output to the terminal may not be wanted.
     /// * `zero_blocks` specifies how zero blocks will be handled. If no value is provided
     ///   (`None`), then all blocks will be uploaded.
+    /// * `kms_key_id` is the KMS key ARN to use for encryption.
+    #[allow(clippy::too_many_arguments)]
     pub async fn upload_from_file<P: AsRef<Path>>(
         &self,
         path: P,
@@ -86,6 +88,7 @@ impl SnapshotUploader {
         tags: Option<Vec<Tag>>,
         progress_bar: Option<ProgressBar>,
         zero_blocks: Option<ZeroBlocks>,
+        kms_key_id: Option<String>,
     ) -> Result<String> {
         let path = path.as_ref();
         let description = description.map(|s| s.to_string()).unwrap_or_else(|| {
@@ -120,7 +123,9 @@ impl SnapshotUploader {
 
         // Start the snapshot, which gives us the ID and block size we need.
         debug!("Uploading {volume_size}G to snapshot...");
-        let (snapshot_id, block_size) = self.start_snapshot(volume_size, description, tags).await?;
+        let (snapshot_id, block_size) = self
+            .start_snapshot(volume_size, description, tags, kms_key_id)
+            .await?;
         let file_blocks = (file_size + i64::from(block_size - 1)) / i64::from(block_size);
         let file_blocks =
             i32::try_from(file_blocks).with_context(|_| error::ConvertNumberSnafu {
@@ -276,17 +281,23 @@ impl SnapshotUploader {
         volume_size: i64,
         description: String,
         tags: Option<Vec<Tag>>,
+        kms_key_id: Option<String>,
     ) -> Result<(String, i32)> {
-        let start_response = self
+        let mut request = self
             .ebs_client
             .start_snapshot()
             .volume_size(volume_size)
             .set_description(Some(description))
             .set_tags(tags)
-            .set_timeout(Some(SNAPSHOT_TIMEOUT_MINUTES))
-            .send()
-            .await
-            .context(error::StartSnapshotSnafu)?;
+            .set_timeout(Some(SNAPSHOT_TIMEOUT_MINUTES));
+
+        if let Some(kms_key_id) = kms_key_id {
+            request = request
+                .set_encrypted(Some(true))
+                .set_kms_key_arn(Some(kms_key_id));
+        }
+
+        let start_response = request.send().await.context(error::StartSnapshotSnafu)?;
 
         let snapshot_id = start_response
             .snapshot_id


### PR DESCRIPTION
**Issue #, if available:**
Fixes #126

**Description of changes:**
Support an optional KMS key ID parameter so that the encryption key used for snapshots can be customized.

**Testing done:**

Verified that the CLI option works:
```
❯ cargo run --release -- upload deny.toml
    Finished `release` profile [optimized] target(s) in 0.11s
     Running `target/release/coldsnap upload deny.toml`
snap-03b152259dd8c91c3

❯ aws ec2 describe-snapshots --snapshot-ids snap-03b152259dd8c91c3 --query 'Snapshots[0].{Encrypted:Encrypted,KmsKeyId:KmsKeyId}' --output json | jq -r '"Encrypted: \(.Encrypted), KMS Key: \(.KmsKeyId // "default")"'
Encrypted: false, KMS Key: default

❯ cargo run --release -- upload --kms-key-id $KEY deny.toml
    Finished `release` profile [optimized] target(s) in 0.10s
     Running `target/release/coldsnap upload --kms-key-id $KEY deny.toml`
snap-0417ba7f6f13ed361

❯ aws ec2 describe-snapshots --snapshot-ids snap-0417ba7f6f13ed361 --query 'Snapshots[0].{Encrypted:Encrypted,KmsKeyId:KmsKeyId}' --output json | jq -r '"Encrypted: \(.Encrypted), KMS Key: \(.KmsKeyId // "default")"'
Encrypted: true, KMS Key: $KEY
```

I also tested the library interface by way of Twoliter and pubsys. 

**Terms of contribution:**
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
