### PR TITLE
limit permissions of GITHUB_TOKEN in actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 on:
   # triggers when a PR is posted
   pull_request:


### PR DESCRIPTION
*Description of changes:*

Explicitly set the permissions in the GitHub Actions workflow to read-only access of the contents.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
