### PR TITLE
Support credential-process method of AWS credential retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,6 +1826,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +1989,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ aws-sdk-rust-rustls = [ ]
 [dependencies]
 argh = "0.1"
 async-trait = "0.1"
-aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "credentials-process", "default-https-client", "rt-tokio"] }
 aws-sdk-ebs = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-ec2 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-types = "1"


### PR DESCRIPTION
*Description of changes:*
In @ajrudzitis' development environment, their profile relies on a [credential process](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-sourcing-external.html) for retrieving credentials. @ajrudzitis confirmed this works through the aws cli but was not working when @ajrudzitis passed the same profile using the `--profile` flag.  Based on this text in the README, @ajrudzitis would expect this would work:

```
Coldsnap uses the same credential mechanisms as the aws cli. For example, if you have credentials in ~/.aws/credentials, these will be used. You can specify the name of the profile to be used by adding --profile profile-name
```

It appears the issue is that the aws config dependency is not compiled with support for retrieving creds from a process. ~~While enabling this, we should also enable sso support.~~

@ajrudzitis confirmed after enabling this feature in the dependency, @ajrudzitis was able to use creds from my profile. 

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
