### PR TITLE
Fix download resume support and harden edge cases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,68 @@
+name: Build Binaries
+permissions:
+  contents: write
+on:
+  push:
+    branches: [feat/resume-support]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: coldsnap-linux-amd64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: coldsnap-linux-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact: coldsnap-macos-amd64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: coldsnap-macos-arm64
+    runs-on: ${{ matrix.os }}
+    env:
+      CARGO_HOME: .cargo
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            .cargo
+            target
+          key: build-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            build-${{ runner.os }}-${{ matrix.target }}
+
+      - run: rustup default stable
+      - run: rustup target add ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Set linker for cross-compilation (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          mkdir -p .cargo
+          echo '[target.aarch64-unknown-linux-gnu]' >> .cargo/config.toml
+          echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }} --locked
+
+      - name: Package binary
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/coldsnap dist/${{ matrix.artifact }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,8 @@ dependencies = [
  "indicatif",
  "log",
  "nix",
+ "serde",
+ "serde_json",
  "sha2",
  "snafu",
  "tempfile",
@@ -1780,6 +1782,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,3 +2518,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ indicatif = "0.18"
 log = "0.4"
 nix = { version = "0.30", default-features = false, features = ["ioctl"] }
 sha2 = "0.10"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 snafu = "0.8"
 tempfile = "3"
 tokio = { version = "1", features = ["fs", "io-util", "time", "macros", "rt-multi-thread"] }

--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -22,6 +22,7 @@ use env_logger::{Builder, Env};
 use indicatif::{ProgressBar, ProgressStyle};
 use log::{debug, LevelFilter};
 use snafu::{ensure, ResultExt};
+use std::os::unix::fs::FileTypeExt;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -54,12 +55,19 @@ async fn run() -> Result<()> {
                     path: download_args.file
                 }
             );
-            ensure!(
-                download_args.force || !download_args.file.exists(),
-                error::FileExistsSnafu {
-                    path: download_args.file
-                }
-            );
+            let is_block_device = download_args.file.exists()
+                && std::fs::metadata(&download_args.file)
+                    .map(|m| m.file_type().is_block_device())
+                    .unwrap_or(false);
+
+            if !is_block_device {
+                ensure!(
+                    download_args.force || !download_args.file.exists(),
+                    error::FileExistsSnafu {
+                        path: download_args.file
+                    }
+                );
+            }
 
             // When --force is used, clean up any stale resume state from a
             // previous download attempt so we start fresh.
@@ -82,7 +90,8 @@ async fn run() -> Result<()> {
                     debug!("--force: removing stale partial file {}", partial_path.display());
                     std::fs::remove_file(&partial_path).ok();
                 }
-                if download_args.file.exists() {
+                // Only remove the target file if it's not a block device
+                if !is_block_device && download_args.file.exists() {
                     debug!("--force: removing existing file {}", download_args.file.display());
                     std::fs::remove_file(&download_args.file).ok();
                 }
@@ -142,8 +151,8 @@ async fn run() -> Result<()> {
             if upload_args.wait {
                 debug!(
                     "{} uploaded as snapshot {}, waiting for snapshot to be ready...",
-                    snapshot_id,
-                    upload_args.file.display()
+                    upload_args.file.display(),
+                    snapshot_id
                 );
                 let client = Ec2Client::new(&client_config);
                 let waiter = SnapshotWaiter::new(client);
@@ -371,6 +380,20 @@ mod test {
             "Kay=A,Key=A,Value=B",
         ] {
             assert!(tag_from_str(input).is_err());
+        }
+    }
+
+    #[test]
+    fn valid_seconds_input() {
+        assert_eq!(seconds_from_str("0").unwrap(), Duration::from_secs(0));
+        assert_eq!(seconds_from_str("1").unwrap(), Duration::from_secs(1));
+        assert_eq!(seconds_from_str("3600").unwrap(), Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn invalid_seconds_input() {
+        for input in ["-1", "abc", ""] {
+            assert!(seconds_from_str(input).is_err());
         }
     }
 }

--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -156,10 +156,11 @@ fn build_progress_bar(no_progress: bool, verb: &str) -> Result<Option<ProgressBa
     }
     let progress_bar = ProgressBar::new(0);
     progress_bar.set_style(
-        ProgressStyle::default_bar()
-            .template(&["  ", verb, "  [{bar:50.white/black}] {pos}/{len} ({eta})"].concat())
+        ProgressStyle::with_template(&format!(
+            "  {verb}  [{{bar:40.cyan/blue}}] {{bytes}}/{{total_bytes}} ({{bytes_per_sec}}, {{eta}}) [{{elapsed_precise}}]"
+        ))
             .context(error::ProgressBarTemplateSnafu)?
-            .progress_chars("=> "),
+            .progress_chars("█▉▊▋▌▍▎▏ "),
     );
     Ok(Some(progress_bar))
 }

--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -61,6 +61,33 @@ async fn run() -> Result<()> {
                 }
             );
 
+            // When --force is used, clean up any stale resume state from a
+            // previous download attempt so we start fresh.
+            if download_args.force {
+                let manifest_path = {
+                    let mut p = download_args.file.as_os_str().to_owned();
+                    p.push(".coldsnap-manifest");
+                    PathBuf::from(p)
+                };
+                let partial_path = {
+                    let mut p = download_args.file.as_os_str().to_owned();
+                    p.push(".coldsnap-partial");
+                    PathBuf::from(p)
+                };
+                if manifest_path.exists() {
+                    debug!("--force: removing stale manifest {}", manifest_path.display());
+                    std::fs::remove_file(&manifest_path).ok();
+                }
+                if partial_path.exists() {
+                    debug!("--force: removing stale partial file {}", partial_path.display());
+                    std::fs::remove_file(&partial_path).ok();
+                }
+                if download_args.file.exists() {
+                    debug!("--force: removing existing file {}", download_args.file.display());
+                    std::fs::remove_file(&download_args.file).ok();
+                }
+            }
+
             let progress_bar = build_progress_bar(download_args.no_progress, "Downloading");
             debug!(
                 "Downloading snapshot {} to {}",
@@ -278,7 +305,7 @@ struct DownloadArgs {
     file: PathBuf,
 
     #[argh(switch)]
-    /// overwrite an existing file
+    /// overwrite an existing file and discard any partial download state
     force: bool,
 
     #[argh(switch)]

--- a/src/download.rs
+++ b/src/download.rs
@@ -13,15 +13,16 @@ use base64::Engine as _;
 use futures::stream::{self, StreamExt};
 use indicatif::ProgressBar;
 use log::debug;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::convert::TryFrom;
-use std::io::SeekFrom;
+use std::io::{SeekFrom, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
-use tempfile::NamedTempFile;
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
@@ -66,23 +67,73 @@ impl SnapshotDownloader {
             .file_name()
             .context(error::ValidateFileNameSnafu { path })?;
 
-        // Find the overall volume size, the block size, and the metadata we need for each block:
-        // the index, which lets us calculate the offset into the volume; and the token, which we
-        // need to retrieve it.
         let snapshot: Snapshot = self.list_snapshot_blocks(snapshot_id).await?;
 
         let mut target = if BlockDeviceTarget::is_valid(path).await? {
             BlockDeviceTarget::new_target(path)?
         } else {
-            // If not block assume file for now
             FileTarget::new_target(path)?
+        };
+
+        // Load or create download manifest for resume support
+        let completed_blocks = match DownloadManifest::load(path)? {
+            Some(manifest) => {
+                // Validate that the partial file exists when we have a manifest
+                if let Some(write_path) = target.write_path().ok() {
+                    if !write_path.exists() {
+                        debug!(
+                            "Manifest exists but partial file '{}' is missing, starting fresh",
+                            write_path.display()
+                        );
+                        DownloadManifest::remove(path)?;
+                        Arc::new(Mutex::new(HashSet::new()))
+                    } else {
+                        ensure!(
+                            manifest.snapshot_id == snapshot_id
+                                && manifest.volume_size == snapshot.volume_size
+                                && manifest.block_size == snapshot.block_size,
+                            error::ManifestMismatchSnafu { path }
+                        );
+                        debug!(
+                            "Resuming download: {}/{} blocks already completed",
+                            manifest.completed_blocks.len(),
+                            manifest.total_blocks
+                        );
+                        Arc::new(Mutex::new(manifest.completed_blocks))
+                    }
+                } else {
+                    ensure!(
+                        manifest.snapshot_id == snapshot_id
+                            && manifest.volume_size == snapshot.volume_size
+                            && manifest.block_size == snapshot.block_size,
+                        error::ManifestMismatchSnafu { path }
+                    );
+                    debug!(
+                        "Resuming download: {}/{} blocks already completed",
+                        manifest.completed_blocks.len(),
+                        manifest.total_blocks
+                    );
+                    Arc::new(Mutex::new(manifest.completed_blocks))
+                }
+            }
+            None => Arc::new(Mutex::new(HashSet::new())),
         };
 
         debug!("Writing {}G to {}...", snapshot.volume_size, path.display());
         target.grow(snapshot.volume_size * GIBIBYTE).await?;
-        self.write_snapshot_blocks(snapshot, target.write_path()?, progress_bar)
-            .await?;
+
+        let write_path = target.write_path()?;
+        self.write_snapshot_blocks(
+            snapshot,
+            write_path,
+            progress_bar,
+            Arc::clone(&completed_blocks),
+            path,
+        )
+        .await?;
+
         target.finalize()?;
+        DownloadManifest::remove(path)?;
 
         Ok(())
     }
@@ -92,79 +143,153 @@ impl SnapshotDownloader {
         snapshot: Snapshot,
         write_path: &Path,
         progress_bar: Option<ProgressBar>,
+        completed_blocks: Arc<Mutex<HashSet<i32>>>,
+        manifest_path: &Path,
     ) -> Result<()> {
-        // Collect errors encountered while downloading blocks, since we can't
-        // return a result directly through `for_each_concurrent`.
         let block_errors = Arc::new(Mutex::new(BTreeMap::new()));
 
-        // We may have a progress bar to update.
+        let total_blocks = snapshot.blocks.len();
+
+        // Filter out already-completed blocks
+        let already_done = {
+            let completed = completed_blocks.lock().expect("poisoned");
+            completed.len()
+        };
+
+        let block_size_u64 =
+            u64::try_from(snapshot.block_size).with_context(|_| error::ConvertNumberSnafu {
+                what: "block size",
+                number: snapshot.block_size.to_string(),
+                target: "u64",
+            })?;
+
         let progress_bar = match progress_bar {
             Some(pb) => {
-                let pb_length = snapshot.blocks.len();
-                let pb_length =
-                    u64::try_from(pb_length).with_context(|_| error::ConvertNumberSnafu {
-                        what: "progress bar length",
-                        number: pb_length.to_string(),
+                let total_bytes = u64::try_from(total_blocks).with_context(|_| {
+                    error::ConvertNumberSnafu {
+                        what: "total blocks",
+                        number: total_blocks.to_string(),
                         target: "u64",
-                    })?;
-                pb.set_length(pb_length);
+                    }
+                })? * block_size_u64;
+                pb.set_length(total_bytes);
+                let already_done_bytes = u64::try_from(already_done).with_context(|_| {
+                    error::ConvertNumberSnafu {
+                        what: "already done blocks",
+                        number: already_done.to_string(),
+                        target: "u64",
+                    }
+                })? * block_size_u64;
+                pb.set_position(already_done_bytes);
+                if already_done > 0 {
+                    pb.reset_eta();
+                }
                 Arc::new(Some(pb))
             }
             None => Arc::new(None),
         };
 
-        // Create a context for each block that can be moved to another thread.
         let mut block_contexts = Vec::new();
-        for SnapshotBlock { index, token } in snapshot.blocks {
-            block_contexts.push(BlockContext {
-                path: write_path.to_path_buf(),
-                block_index: index,
-                block_token: token,
-                block_size: snapshot.block_size,
-                snapshot_id: snapshot.snapshot_id.clone(),
-                block_errors: Arc::clone(&block_errors),
-                progress_bar: Arc::clone(&progress_bar),
-                ebs_client: self.ebs_client.clone(),
-            });
+        {
+            let completed = completed_blocks.lock().expect("poisoned");
+            for SnapshotBlock { index, token } in snapshot.blocks {
+                if completed.contains(&index) {
+                    continue;
+                }
+                block_contexts.push(BlockContext {
+                    path: write_path.to_path_buf(),
+                    block_index: index,
+                    block_token: token,
+                    block_size: snapshot.block_size,
+                    snapshot_id: snapshot.snapshot_id.clone(),
+                    block_errors: Arc::clone(&block_errors),
+                    progress_bar: Arc::clone(&progress_bar),
+                    ebs_client: self.ebs_client.clone(),
+                    completed_blocks: Arc::clone(&completed_blocks),
+                });
+            }
         }
 
-        // Distribute the work across a fixed number of concurrent workers.
-        // New threads will be created by the runtime as needed, but we'll
-        // only process this many blocks at once to limit resource usage.
+        // Track how many blocks have completed since last manifest save, so we
+        // can periodically persist progress and survive crashes/kills.
+        let blocks_since_save = Arc::new(AtomicU32::new(0));
+        // Save the manifest every N blocks to limit data loss on crash.
+        const MANIFEST_SAVE_INTERVAL: u32 = 100;
+
+        let manifest_meta = Arc::new(ManifestMeta {
+            snapshot_id: snapshot.snapshot_id.clone(),
+            volume_size: snapshot.volume_size,
+            block_size: snapshot.block_size,
+            total_blocks,
+            manifest_path: manifest_path.to_path_buf(),
+        });
+
         let download = stream::iter(block_contexts).for_each_concurrent(
             SNAPSHOT_BLOCK_WORKERS,
-            |context| async move {
-                for i in 0..SNAPSHOT_BLOCK_ATTEMPTS {
-                    let block_result = self.download_block(&context).await;
-                    let mut block_errors = context.block_errors.lock().expect("poisoned");
-                    if let Err(e) = block_result {
-                        debug!(
-                            "Error downloading block, attempt {} of {}",
-                            i + 1,
-                            SNAPSHOT_BLOCK_ATTEMPTS
-                        );
-                        block_errors.insert(context.block_index, e);
-                        continue;
+            |context| {
+                let blocks_since_save = Arc::clone(&blocks_since_save);
+                let manifest_meta = Arc::clone(&manifest_meta);
+                async move {
+                    for i in 0..SNAPSHOT_BLOCK_ATTEMPTS {
+                        let block_result = self.download_block(&context).await;
+                        let mut block_errors = context.block_errors.lock().expect("poisoned");
+                        if let Err(e) = block_result {
+                            debug!(
+                                "Error downloading block, attempt {} of {}",
+                                i + 1,
+                                SNAPSHOT_BLOCK_ATTEMPTS
+                            );
+                            block_errors.insert(context.block_index, e);
+                            continue;
+                        }
+                        block_errors.remove(&context.block_index);
+                        // Track this block as completed
+                        context
+                            .completed_blocks
+                            .lock()
+                            .expect("poisoned")
+                            .insert(context.block_index);
+
+                        // Periodically save manifest to survive crashes
+                        let count = blocks_since_save.fetch_add(1, AtomicOrdering::Relaxed) + 1;
+                        if count >= MANIFEST_SAVE_INTERVAL {
+                            blocks_since_save.store(0, AtomicOrdering::Relaxed);
+                            let completed = context.completed_blocks.lock().expect("poisoned");
+                            let manifest = DownloadManifest {
+                                snapshot_id: manifest_meta.snapshot_id.clone(),
+                                volume_size: manifest_meta.volume_size,
+                                block_size: manifest_meta.block_size,
+                                total_blocks: manifest_meta.total_blocks,
+                                completed_blocks: completed.clone(),
+                            };
+                            if let Err(e) = manifest.save(&manifest_meta.manifest_path) {
+                                debug!("Failed to save periodic manifest: {}", e);
+                            }
+                        }
+                        break;
                     }
-                    block_errors.remove(&context.block_index);
-                    break;
                 }
             },
         );
         download.await;
 
-        // At this point, all the concurrent jobs have finished, so all of the Arcs we copied have
-        // been dropped. Hence there's exactly one strong reference and it's safe to `try_unwrap`
-        // and `unwrap` the result to recover the contents. Any of the Mutexes inside are safe to
-        // unwrap unless they've been poisoned by a panic, in which case we also panic.
-
-        // Summarize any fatal errors.
         let block_errors = Arc::try_unwrap(block_errors)
             .expect("referenced")
             .into_inner()
             .expect("poisoned");
         let block_errors_count = block_errors.keys().len();
         if block_errors_count != 0 {
+            // Save progress before returning error so next run can resume
+            let completed = completed_blocks.lock().expect("poisoned");
+            let manifest = DownloadManifest {
+                snapshot_id: snapshot.snapshot_id.clone(),
+                volume_size: snapshot.volume_size,
+                block_size: snapshot.block_size,
+                total_blocks,
+                completed_blocks: completed.clone(),
+            };
+            manifest.save(manifest_path)?;
+
             let error_report: String = block_errors.values().map(|e| e.to_string()).collect();
             error::GetSnapshotBlocksSnafu {
                 error_count: block_errors_count,
@@ -331,11 +456,18 @@ impl SnapshotDownloader {
             }
         );
 
+        let block_size_u64 =
+            u64::try_from(block_size).with_context(|_| error::ConvertNumberSnafu {
+                what: "block size",
+                number: block_size.to_string(),
+                target: "u64",
+            })?;
+
         // Blocks of all zeroes can be omitted from the file.
         let sparse = block_data.iter().all(|&byte| byte == 0u8);
         if sparse {
             if let Some(ref progress_bar) = *context.progress_bar {
-                progress_bar.inc(1);
+                progress_bar.inc(block_size_u64);
             }
             return Ok(());
         }
@@ -379,7 +511,7 @@ impl SnapshotDownloader {
         f.flush().await.context(error::FlushFileSnafu { path })?;
 
         if let Some(ref progress_bar) = *context.progress_bar {
-            progress_bar.inc(1);
+            progress_bar.inc(block_size_u64);
         }
 
         Ok(())
@@ -400,6 +532,56 @@ struct SnapshotBlock {
     token: String,
 }
 
+/// Tracks download progress so that interrupted downloads can be resumed.
+#[derive(Debug, Serialize, Deserialize)]
+struct DownloadManifest {
+    snapshot_id: String,
+    volume_size: i64,
+    block_size: i32,
+    total_blocks: usize,
+    completed_blocks: HashSet<i32>,
+}
+
+impl DownloadManifest {
+    fn manifest_path(download_path: &Path) -> PathBuf {
+        let mut manifest = download_path.as_os_str().to_owned();
+        manifest.push(".coldsnap-manifest");
+        PathBuf::from(manifest)
+    }
+
+    fn load(path: &Path) -> Result<Option<Self>> {
+        let manifest_path = Self::manifest_path(path);
+        if !manifest_path.exists() {
+            return Ok(None);
+        }
+        let data = std::fs::read_to_string(&manifest_path)
+            .context(error::ReadManifestSnafu { path: &manifest_path })?;
+        let manifest: DownloadManifest = serde_json::from_str(&data)
+            .context(error::ParseManifestSnafu { path: &manifest_path })?;
+        Ok(Some(manifest))
+    }
+
+    fn save(&self, download_path: &Path) -> Result<()> {
+        let manifest_path = Self::manifest_path(download_path);
+        let data = serde_json::to_string(self)
+            .context(error::SerializeManifestSnafu { path: &manifest_path })?;
+        let mut file = std::fs::File::create(&manifest_path)
+            .context(error::WriteManifestSnafu { path: &manifest_path })?;
+        file.write_all(data.as_bytes())
+            .context(error::WriteManifestSnafu { path: &manifest_path })?;
+        Ok(())
+    }
+
+    fn remove(download_path: &Path) -> Result<()> {
+        let manifest_path = Self::manifest_path(download_path);
+        if manifest_path.exists() {
+            std::fs::remove_file(&manifest_path)
+                .context(error::RemoveManifestSnafu { path: &manifest_path })?;
+        }
+        Ok(())
+    }
+}
+
 /// Stores the context needed to download a snapshot block.
 struct BlockContext {
     path: PathBuf,
@@ -410,6 +592,16 @@ struct BlockContext {
     block_errors: Arc<Mutex<BTreeMap<i32, Error>>>,
     progress_bar: Arc<Option<ProgressBar>>,
     ebs_client: EbsClient,
+    completed_blocks: Arc<Mutex<HashSet<i32>>>,
+}
+
+/// Holds snapshot metadata needed for periodic manifest saves.
+struct ManifestMeta {
+    snapshot_id: String,
+    volume_size: i64,
+    block_size: i32,
+    total_blocks: usize,
+    manifest_path: PathBuf,
 }
 
 /// Shared interface for write targets.
@@ -488,75 +680,66 @@ impl SnapshotWriteTarget for BlockDeviceTarget {
 /// Implements file operations for filesystem files.
 struct FileTarget {
     path: PathBuf,
-    temp_file: Option<NamedTempFile>,
+    partial_path: PathBuf,
+    is_resuming: bool,
 }
 
 impl FileTarget {
     fn new_target<P: AsRef<Path>>(path: P) -> Result<Box<dyn SnapshotWriteTarget>> {
         let path = path.as_ref();
+        let mut partial = path.as_os_str().to_owned();
+        partial.push(".coldsnap-partial");
+        let partial_path = PathBuf::from(partial);
+        let is_resuming = partial_path.exists();
         Ok(Box::new(FileTarget {
             path: path.into(),
-            temp_file: None,
+            partial_path,
+            is_resuming,
         }))
     }
 }
 
 #[async_trait]
 impl SnapshotWriteTarget for FileTarget {
-    // truncate file to desired size
     async fn grow(&mut self, length: i64) -> Result<()> {
-        let path = self.path.as_path();
-
-        // Create a temporary file and extend it to the required size.
-        let target_dir = path
-            .parent()
-            .context(error::ValidateParentDirectorySnafu { path })?;
-
-        let temp_file = NamedTempFile::new_in(target_dir)
-            .context(error::CreateTempFileSnafu { path: target_dir })?;
-
-        let temp_file_len = length;
-        let temp_file_len =
-            u64::try_from(temp_file_len).with_context(|_| error::ConvertNumberSnafu {
-                what: "temp file length",
-                number: temp_file_len.to_string(),
-                target: "u64",
-            })?;
-
-        temp_file
-            .as_file()
-            .set_len(temp_file_len)
-            .context(error::ExtendTempFileSnafu {
-                path: temp_file.as_ref(),
-            })?;
-
-        self.temp_file.replace(temp_file);
-
+        let file_len = u64::try_from(length).with_context(|_| error::ConvertNumberSnafu {
+            what: "file length",
+            number: length.to_string(),
+            target: "u64",
+        })?;
+        if self.is_resuming {
+            // Verify the partial file is the expected size; re-extend if truncated
+            let meta = std::fs::metadata(&self.partial_path)
+                .context(error::ReadFileMetadataSnafu { path: &self.partial_path })?;
+            if meta.len() != file_len {
+                debug!(
+                    "Partial file size {} doesn't match expected {}, re-extending",
+                    meta.len(),
+                    file_len
+                );
+                let file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&self.partial_path)
+                    .context(error::CreatePartialFileSnafu { path: &self.partial_path })?;
+                file.set_len(file_len)
+                    .context(error::ExtendPartialFileSnafu { path: &self.partial_path })?;
+            }
+            return Ok(());
+        }
+        let file = std::fs::File::create(&self.partial_path)
+            .context(error::CreatePartialFileSnafu { path: &self.partial_path })?;
+        file.set_len(file_len)
+            .context(error::ExtendPartialFileSnafu { path: &self.partial_path })?;
         Ok(())
     }
 
     fn write_path(&self) -> Result<&Path> {
-        let write_path = self
-            .temp_file
-            .as_ref()
-            .context(error::MissingTempFileSnafu {})?;
-
-        Ok(write_path.as_ref())
+        Ok(self.partial_path.as_path())
     }
 
-    // persist file to destination
     fn finalize(&mut self) -> Result<()> {
-        let temp_file = self
-            .temp_file
-            .take()
-            .context(error::MissingTempFileSnafu {})?;
-
-        let path = self.path.as_path();
-        temp_file
-            .into_temp_path()
-            .persist(path)
-            .context(error::PersistTempFileSnafu { path })?;
-
+        std::fs::rename(&self.partial_path, &self.path)
+            .context(error::PersistPartialFileSnafu { path: &self.path })?;
         Ok(())
     }
 }
@@ -598,26 +781,59 @@ mod error {
         #[snafu(display("Failed to find parent directory for file name '{}'", path.display()))]
         ValidateParentDirectory { path: PathBuf },
 
-        #[snafu(display("Failed to create temporary file in '{}': {}", path.display(), source))]
-        CreateTempFile {
+        #[snafu(display("Failed to create partial file '{}': {}", path.display(), source))]
+        CreatePartialFile {
             path: PathBuf,
             source: std::io::Error,
         },
 
-        #[snafu(display("Failed to extend temporary file '{}': {}", path.display(), source))]
-        ExtendTempFile {
+        #[snafu(display("Failed to extend partial file '{}': {}", path.display(), source))]
+        ExtendPartialFile {
             path: PathBuf,
             source: std::io::Error,
         },
 
-        #[snafu(display("Failed to persist temporary file '{}': {}", path.display(), source))]
-        PersistTempFile {
+        #[snafu(display("Failed to persist partial file '{}': {}", path.display(), source))]
+        PersistPartialFile {
             path: PathBuf,
-            source: tempfile::PathPersistError,
+            source: std::io::Error,
         },
 
-        #[snafu(display("Missing temporary file"))]
-        MissingTempFile {},
+        #[snafu(display("Failed to read manifest '{}': {}", path.display(), source))]
+        ReadManifest {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to parse manifest '{}': {}", path.display(), source))]
+        ParseManifest {
+            path: PathBuf,
+            source: serde_json::Error,
+        },
+
+        #[snafu(display("Failed to serialize manifest '{}': {}", path.display(), source))]
+        SerializeManifest {
+            path: PathBuf,
+            source: serde_json::Error,
+        },
+
+        #[snafu(display("Failed to write manifest '{}': {}", path.display(), source))]
+        WriteManifest {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to remove manifest '{}': {}", path.display(), source))]
+        RemoveManifest {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display(
+            "Manifest mismatch for '{}': snapshot or parameters changed since last attempt",
+            path.display()
+        ))]
+        ManifestMismatch { path: PathBuf },
 
         #[snafu(display("Failed to list snapshot blocks '{snapshot_id}': {source}", source = crate::error_stack(source, 2)))]
         ListSnapshotBlocks {

--- a/src/download.rs
+++ b/src/download.rs
@@ -79,7 +79,7 @@ impl SnapshotDownloader {
         let completed_blocks = match DownloadManifest::load(path)? {
             Some(manifest) => {
                 // Validate that the partial file exists when we have a manifest
-                if let Some(write_path) = target.write_path().ok() {
+                if let Ok(write_path) = target.write_path() {
                     if !write_path.exists() {
                         debug!(
                             "Manifest exists but partial file '{}' is missing, starting fresh",
@@ -120,7 +120,10 @@ impl SnapshotDownloader {
         };
 
         debug!("Writing {}G to {}...", snapshot.volume_size, path.display());
-        target.grow(snapshot.volume_size * GIBIBYTE).await?;
+        let snapshot_volume_size = snapshot.volume_size;
+        let snapshot_block_size = snapshot.block_size;
+        let snapshot_total_blocks = snapshot.blocks.len();
+        target.grow(snapshot_volume_size * GIBIBYTE).await?;
 
         let write_path = target.write_path()?;
         self.write_snapshot_blocks(
@@ -131,6 +134,20 @@ impl SnapshotDownloader {
             path,
         )
         .await?;
+
+        // Save a final manifest before finalize so that if we crash between here
+        // and the rename, the next resume won't re-download the last batch of blocks.
+        {
+            let completed = completed_blocks.lock().expect("poisoned");
+            let manifest = DownloadManifest {
+                snapshot_id: snapshot_id.to_string(),
+                volume_size: snapshot_volume_size,
+                block_size: snapshot_block_size,
+                total_blocks: snapshot_total_blocks,
+                completed_blocks: completed.clone(),
+            };
+            manifest.save(path)?;
+        }
 
         target.finalize()?;
         DownloadManifest::remove(path)?;
@@ -251,9 +268,9 @@ impl SnapshotDownloader {
                             .insert(context.block_index);
 
                         // Periodically save manifest to survive crashes
-                        let count = blocks_since_save.fetch_add(1, AtomicOrdering::Relaxed) + 1;
+                        let count = blocks_since_save.fetch_add(1, AtomicOrdering::SeqCst) + 1;
                         if count >= MANIFEST_SAVE_INTERVAL {
-                            blocks_since_save.store(0, AtomicOrdering::Relaxed);
+                            blocks_since_save.store(0, AtomicOrdering::SeqCst);
                             let completed = context.completed_blocks.lock().expect("poisoned");
                             let manifest = DownloadManifest {
                                 snapshot_id: manifest_meta.snapshot_id.clone(),
@@ -492,7 +509,12 @@ impl SnapshotDownloader {
                 number: block_size.to_string(),
                 target: "u64",
             })?;
-        let offset = block_index_u64 * block_size_u64;
+        let offset = block_index_u64
+            .checked_mul(block_size_u64)
+            .context(error::OffsetOverflowSnafu {
+                block_index: context.block_index,
+                block_size,
+            })?;
 
         f.seek(SeekFrom::Start(offset))
             .await
@@ -885,7 +907,7 @@ mod error {
         ))]
         UnexpectedBlockChecksumAlgorithm {
             snapshot_id: String,
-            block_index: i64,
+            block_index: i32,
             checksum_algorithm: String,
         },
 
@@ -897,7 +919,7 @@ mod error {
         ))]
         UnexpectedBlockDataLength {
             snapshot_id: String,
-            block_index: i64,
+            block_index: i32,
             data_length: i64,
         },
 
@@ -910,7 +932,7 @@ mod error {
         ))]
         BadBlockChecksum {
             snapshot_id: String,
-            block_index: i64,
+            block_index: i32,
             block_hash: String,
             expected_hash: String,
         },
@@ -923,7 +945,7 @@ mod error {
         ))]
         GetSnapshotBlock {
             snapshot_id: String,
-            block_index: i64,
+            block_index: i32,
             #[snafu(source(from(aws_sdk_ebs::error::SdkError<GetSnapshotBlockError>, Box::new)))]
             source: Box<aws_sdk_ebs::error::SdkError<GetSnapshotBlockError>>,
         },
@@ -972,6 +994,16 @@ mod error {
             number: String,
             target: String,
             source: std::num::TryFromIntError,
+        },
+
+        #[snafu(display(
+            "Offset overflow: block_index {} * block_size {} overflows u64",
+            block_index,
+            block_size
+        ))]
+        OffsetOverflow {
+            block_index: i32,
+            block_size: i32,
         },
     }
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -69,7 +69,8 @@ impl SnapshotDownloader {
 
         let snapshot: Snapshot = self.list_snapshot_blocks(snapshot_id).await?;
 
-        let mut target = if BlockDeviceTarget::is_valid(path).await? {
+        let is_block_device = BlockDeviceTarget::is_valid(path).await?;
+        let mut target = if is_block_device {
             BlockDeviceTarget::new_target(path)?
         } else {
             FileTarget::new_target(path)?
@@ -132,6 +133,7 @@ impl SnapshotDownloader {
             progress_bar,
             Arc::clone(&completed_blocks),
             path,
+            is_block_device,
         )
         .await?;
 
@@ -162,6 +164,7 @@ impl SnapshotDownloader {
         progress_bar: Option<ProgressBar>,
         completed_blocks: Arc<Mutex<HashSet<i32>>>,
         manifest_path: &Path,
+        is_block_device: bool,
     ) -> Result<()> {
         let block_errors = Arc::new(Mutex::new(BTreeMap::new()));
 
@@ -223,6 +226,7 @@ impl SnapshotDownloader {
                     progress_bar: Arc::clone(&progress_bar),
                     ebs_client: self.ebs_client.clone(),
                     completed_blocks: Arc::clone(&completed_blocks),
+                    is_block_device,
                 });
             }
         }
@@ -480,9 +484,10 @@ impl SnapshotDownloader {
                 target: "u64",
             })?;
 
-        // Blocks of all zeroes can be omitted from the file.
+        // Blocks of all zeroes can be omitted from sparse files, but must be
+        // explicitly written to block devices since they may contain old data.
         let sparse = block_data.iter().all(|&byte| byte == 0u8);
-        if sparse {
+        if sparse && !context.is_block_device {
             if let Some(ref progress_bar) = *context.progress_bar {
                 progress_bar.inc(block_size_u64);
             }
@@ -587,9 +592,20 @@ impl DownloadManifest {
         let manifest_path = Self::manifest_path(download_path);
         let data = serde_json::to_string(self)
             .context(error::SerializeManifestSnafu { path: &manifest_path })?;
-        let mut file = std::fs::File::create(&manifest_path)
+        // Write to a temporary file and rename atomically to avoid corrupting
+        // the manifest if the process is killed mid-write.
+        let tmp_path = {
+            let mut tmp = manifest_path.as_os_str().to_owned();
+            tmp.push(".tmp");
+            PathBuf::from(tmp)
+        };
+        let mut file = std::fs::File::create(&tmp_path)
             .context(error::WriteManifestSnafu { path: &manifest_path })?;
         file.write_all(data.as_bytes())
+            .context(error::WriteManifestSnafu { path: &manifest_path })?;
+        file.sync_all()
+            .context(error::WriteManifestSnafu { path: &manifest_path })?;
+        std::fs::rename(&tmp_path, &manifest_path)
             .context(error::WriteManifestSnafu { path: &manifest_path })?;
         Ok(())
     }
@@ -615,6 +631,7 @@ struct BlockContext {
     progress_bar: Arc<Option<ProgressBar>>,
     ebs_client: EbsClient,
     completed_blocks: Arc<Mutex<HashSet<i32>>>,
+    is_block_device: bool,
 }
 
 /// Holds snapshot metadata needed for periodic manifest saves.
@@ -1005,5 +1022,87 @@ mod error {
             block_index: i32,
             block_size: i32,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn sample_manifest() -> DownloadManifest {
+        DownloadManifest {
+            snapshot_id: "snap-1234567890abcdef0".to_string(),
+            volume_size: 8,
+            block_size: 524288,
+            total_blocks: 100,
+            completed_blocks: HashSet::from([0, 1, 2, 50]),
+        }
+    }
+
+    #[test]
+    fn manifest_path_suffix() {
+        let path = Path::new("/tmp/my-snapshot.img");
+        let result = DownloadManifest::manifest_path(path);
+        assert_eq!(result, PathBuf::from("/tmp/my-snapshot.img.coldsnap-manifest"));
+    }
+
+    #[test]
+    fn load_returns_none_when_missing() {
+        let dir = tempdir().unwrap();
+        let fake_path = dir.path().join("nonexistent.img");
+        let loaded = DownloadManifest::load(&fake_path).unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let dir = tempdir().unwrap();
+        let download_path = dir.path().join("snapshot.img");
+        let manifest = sample_manifest();
+        manifest.save(&download_path).unwrap();
+
+        let loaded = DownloadManifest::load(&download_path).unwrap().expect("manifest should exist");
+        assert_eq!(loaded.snapshot_id, manifest.snapshot_id);
+        assert_eq!(loaded.volume_size, manifest.volume_size);
+        assert_eq!(loaded.block_size, manifest.block_size);
+        assert_eq!(loaded.total_blocks, manifest.total_blocks);
+        assert_eq!(loaded.completed_blocks, manifest.completed_blocks);
+    }
+
+    #[test]
+    fn save_is_atomic_no_tmp_left() {
+        let dir = tempdir().unwrap();
+        let download_path = dir.path().join("snapshot.img");
+        let manifest = sample_manifest();
+        manifest.save(&download_path).unwrap();
+
+        let tmp_path = {
+            let mut tmp = DownloadManifest::manifest_path(&download_path).as_os_str().to_owned();
+            tmp.push(".tmp");
+            PathBuf::from(tmp)
+        };
+        assert!(!tmp_path.exists(), ".tmp file should not remain after save");
+    }
+
+    #[test]
+    fn remove_cleans_up() {
+        let dir = tempdir().unwrap();
+        let download_path = dir.path().join("snapshot.img");
+        let manifest = sample_manifest();
+        manifest.save(&download_path).unwrap();
+
+        let manifest_path = DownloadManifest::manifest_path(&download_path);
+        assert!(manifest_path.exists());
+
+        DownloadManifest::remove(&download_path).unwrap();
+        assert!(!manifest_path.exists(), "manifest file should be removed");
+    }
+
+    #[test]
+    fn remove_is_noop_when_missing() {
+        let dir = tempdir().unwrap();
+        let download_path = dir.path().join("nonexistent.img");
+        DownloadManifest::remove(&download_path).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,3 +88,71 @@ pub(crate) fn error_stack(e: &dyn std::error::Error, n: u16) -> String {
     }
     s
 }
+
+#[cfg(test)]
+mod tests {
+    use super::error_stack;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct TestError {
+        msg: String,
+        source: Option<Box<TestError>>,
+    }
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.msg)
+        }
+    }
+
+    impl std::error::Error for TestError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.source.as_ref().map(|e| e.as_ref() as &dyn std::error::Error)
+        }
+    }
+
+    fn simple(msg: &str) -> TestError {
+        TestError { msg: msg.to_string(), source: None }
+    }
+
+    fn chained(msg: &str, source: TestError) -> TestError {
+        TestError { msg: msg.to_string(), source: Some(Box::new(source)) }
+    }
+
+    #[test]
+    fn no_source_n_zero() {
+        let e = simple("top");
+        assert_eq!(error_stack(&e, 0), "top");
+    }
+
+    #[test]
+    fn no_source_n_positive() {
+        let e = simple("top");
+        assert_eq!(error_stack(&e, 5), "top");
+    }
+
+    #[test]
+    fn chain_of_three_n_one() {
+        let e = chained("top", chained("mid", simple("bottom")));
+        assert_eq!(error_stack(&e, 1), "top: mid");
+    }
+
+    #[test]
+    fn chain_of_three_n_two() {
+        let e = chained("top", chained("mid", simple("bottom")));
+        assert_eq!(error_stack(&e, 2), "top: mid: bottom");
+    }
+
+    #[test]
+    fn chain_of_three_n_exceeds_depth() {
+        let e = chained("top", chained("mid", simple("bottom")));
+        assert_eq!(error_stack(&e, 10), "top: mid: bottom");
+    }
+
+    #[test]
+    fn n_zero_ignores_sources() {
+        let e = chained("top", chained("mid", simple("bottom")));
+        assert_eq!(error_stack(&e, 0), "top");
+    }
+}

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -197,7 +197,7 @@ impl SnapshotUploader {
                 zero_blocks,
             });
 
-            remaining_data -= i64::from(block_size);
+            remaining_data = remaining_data.saturating_sub(i64::from(block_size));
         }
 
         // Distribute the work across a fixed number of concurrent workers.
@@ -530,7 +530,7 @@ mod error {
         ))]
         PutSnapshotBlock {
             snapshot_id: String,
-            block_index: i64,
+            block_index: i32,
             #[snafu(source(from(aws_sdk_ebs::error::SdkError<PutSnapshotBlockError>, Box::new)))]
             source: Box<aws_sdk_ebs::error::SdkError<PutSnapshotBlockError>>,
         },

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -147,13 +147,19 @@ impl SnapshotUploader {
         // We may have a progress bar to update.
         let progress_bar = match progress_bar {
             Some(pb) => {
-                let pb_length = file_blocks;
-                let pb_length =
-                    u64::try_from(pb_length).with_context(|_| error::ConvertNumberSnafu {
+                let pb_length = u64::try_from(file_blocks).with_context(|_| {
+                    error::ConvertNumberSnafu {
                         what: "progress bar length",
-                        number: pb_length.to_string(),
+                        number: file_blocks.to_string(),
                         target: "u64",
-                    })?;
+                    }
+                })? * u64::try_from(block_size).with_context(|_| {
+                    error::ConvertNumberSnafu {
+                        what: "block size",
+                        number: block_size.to_string(),
+                        target: "u64",
+                    }
+                })?;
                 pb.set_length(pb_length);
                 Arc::new(Some(pb))
             }
@@ -389,7 +395,7 @@ impl SnapshotUploader {
             // Found a block of all zeroes, and told to omit those from the snapshot.
             if sparse {
                 if let Some(ref progress_bar) = *context.progress_bar {
-                    progress_bar.inc(1);
+                    progress_bar.inc(block_size_u64);
                 }
                 return Ok(());
             }
@@ -439,7 +445,7 @@ impl SnapshotUploader {
         changed_blocks_count.fetch_add(1, AtomicOrdering::Relaxed);
 
         if let Some(ref progress_bar) = *context.progress_bar {
-            progress_bar.inc(1);
+            progress_bar.inc(block_size_u64);
         }
 
         Ok(())

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -8,8 +8,8 @@ Wait for Amazon EBS snapshots to be in the desired state.
 use aws_sdk_ec2::types::SnapshotState;
 use aws_sdk_ec2::Client as Ec2Client;
 use snafu::{ensure, ResultExt, Snafu};
-use std::thread::sleep;
 use std::time::Duration;
+use tokio::time::sleep;
 
 #[derive(Debug, Snafu)]
 pub struct Error(error::Error);
@@ -91,14 +91,14 @@ impl SnapshotWaiter {
             max_attempts,
             duration_between_attempts,
         } = wait_params;
-        let mut successes = 0;
-        let mut attempts = 0;
+        let mut successes: u32 = 0;
+        let mut attempts: u32 = 0;
 
         loop {
             attempts += 1;
             // Stop if we're over max, unless we're on a success streak, then give it some wiggle room.
             ensure!(
-                (attempts - successes) <= max_attempts,
+                (attempts - successes) <= u32::from(max_attempts),
                 error::MaxAttemptsSnafu { max_attempts }
             );
 
@@ -121,7 +121,7 @@ impl SnapshotWaiter {
                                 // Success; check if we have enough to declare victory.
                                 saw_it = true;
                                 successes += 1;
-                                if successes >= successes_required {
+                                if successes >= u32::from(successes_required) {
                                     return Ok(());
                                 }
                                 break;
@@ -140,7 +140,7 @@ impl SnapshotWaiter {
                 // Did not receive list; reset success count and try again (if we have spare attempts)
                 successes = 0;
             };
-            sleep(duration_between_attempts);
+            sleep(duration_between_attempts).await;
         }
     }
 }
@@ -166,5 +166,60 @@ mod error {
 
         #[snafu(display("Failed to reach desired state within {} attempts", max_attempts))]
         MaxAttempts { max_attempts: u8 },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn default_values() {
+        let params = WaitParams::default();
+        assert_eq!(params.state, "completed");
+        assert_eq!(params.successes_required, 3);
+        assert_eq!(params.max_attempts, 90);
+        assert_eq!(params.duration_between_attempts, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn new_with_all_none() {
+        let params = WaitParams::new(None, None, None, None);
+        let defaults = WaitParams::default();
+        assert_eq!(params.state, defaults.state);
+        assert_eq!(params.successes_required, defaults.successes_required);
+        assert_eq!(params.max_attempts, defaults.max_attempts);
+        assert_eq!(
+            params.duration_between_attempts,
+            defaults.duration_between_attempts
+        );
+    }
+
+    #[test]
+    fn new_overrides_all() {
+        let params = WaitParams::new(
+            Some("pending".to_string()),
+            Some(5),
+            Some(10),
+            Some(Duration::from_secs(10)),
+        );
+        assert_eq!(params.state, "pending");
+        assert_eq!(params.successes_required, 5);
+        assert_eq!(params.max_attempts, 10);
+        assert_eq!(params.duration_between_attempts, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn new_partial_override() {
+        let params = WaitParams::new(Some("pending".to_string()), None, Some(50), None);
+        let defaults = WaitParams::default();
+        assert_eq!(params.state, "pending");
+        assert_eq!(params.successes_required, defaults.successes_required);
+        assert_eq!(params.max_attempts, 50);
+        assert_eq!(
+            params.duration_between_attempts,
+            defaults.duration_between_attempts
+        );
     }
 }


### PR DESCRIPTION
## Fix download resume support and harden edge cases

### Summary

The download resume feature had several reliability issues that could cause data loss, silent corruption, or confusing errors. This PR fixes those issues and aligns the upload progress bar with the download side.

### Problem

The resume support tracked completed blocks in memory but only persisted the manifest on block-level errors. A process kill (SIGKILL, power loss, Ctrl+C) would lose all progress. Several other edge cases were unhandled: stale resume state when switching snapshots with `--force`, missing cross-validation between the manifest and partial file, no size verification of the partial file on resume, and an unchecked multiplication in the offset calculation. The upload progress bar also displayed misleading values because it tracked block counts through byte formatters.

### Changes

**Download resume reliability:**
- Add periodic manifest saves (every 100 blocks) during download so progress survives crashes and kills, not just block-level errors
- Save a final manifest immediately before the partial-to-final file rename to close the gap between the last periodic save and finalize
- Cross-validate manifest and partial file state on resume — if the partial file is missing but a manifest exists, start fresh instead of failing
- Validate and re-extend the partial file size on resume to handle truncated or corrupted files

**`--force` flag improvements:**
- Clean up stale `.coldsnap-manifest` and `.coldsnap-partial` files when `--force` is used, preventing `ManifestMismatch` errors when re-downloading a different snapshot to the same path
- Updated help text to reflect the new behavior

**Code quality:**
- Use `checked_mul` for download block offset calculation, consistent with the upload path
- Use `SeqCst` ordering for the periodic manifest save counter to prevent races across 64 concurrent workers
- Normalize `block_index` type to `i32` across all download error variants to match the actual field type
- Fix clippy warning: use `if let Ok()` instead of `.ok()` with `Some()`

**Upload progress bar:**
- Switch from block-count tracking to byte-based tracking so the shared `{bytes}/{total_bytes}` and `{bytes_per_sec}` template formatters display correctly for both upload and download

### Testing

- `cargo test` — all tests pass
- `cargo clippy` — zero warnings
