### PR TITLE
chore: bump aws-lc-sys from 0.38.0 to 0.39.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
*Description of changes:*
bump aws-lc-sys from 0.38.0 to 0.39.0 by `cargo update -p aws-lc-rs`


*Test:*
`cargo build`
`cargo test`
```
dd if=/dev/urandom of=/tmp/test-file.img bs=1M count=1
AWS_DEFAULT_REGION=us-west-2 cargo run -- upload /tmp/test-file.img
AWS_DEFAULT_REGION=us-west-2 cargo run -- download snap-xxxxx /tmp/downloaded-file.img
cmp -n 1048576 /tmp/test-file.img /tmp/downloaded-file.img
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
