### PR TITLE
licenses: allow ISC and OpenSSL

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,9 +17,9 @@ allow = [
     "BSD-3-Clause",
     "BSL-1.0",
     #"CC0-1.0",  # OK but currently unused; commenting to prevent warning
-    #"ISC",  # OK but currently unused; commenting to prevent warning
+    "ISC",
     "MIT",
-    #"OpenSSL", # OK but currently unused; commenting to prevent warning
+    "OpenSSL",
     "Unicode-3.0",
     "Unlicense",
     #"Zlib",  # OK but currently unused; commenting to prevent warning


### PR DESCRIPTION


*Issue #, if available:*
n/a

*Description of changes:*


  aws-lc-rs, aws-lc-sys, rustls-webpki, and untrusted require ISC and
  OpenSSL licenses. These were commented out in 48b90d5 as "currently
  unused", but they were only appearing unused due to a dependency graph
  pruning bug in cargo-deny's krates dependency (EmbarkStudios/krates#106,
  EmbarkStudios/krates#109), fixed in cargo-deny 0.19.1+.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
