### PR TITLE
Add configurable --workers flag for download

### DIFF
--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -70,6 +70,11 @@ async fn run() -> Result<()> {
                 (true, false) => Some(CheckpointBehavior::Enable),
                 (true, true) => Some(CheckpointBehavior::EnableAndKeep),
             };
+            ensure!(
+                download_args.workers != Some(0),
+                error::InvalidWorkerCountSnafu
+            );
+
             debug!(
                 "Downloading snapshot {} to {}",
                 download_args.snapshot_id,
@@ -81,6 +86,7 @@ async fn run() -> Result<()> {
                     &download_args.file,
                     progress_bar?,
                     checkpoint,
+                    download_args.workers,
                 )
                 .await
                 .context(error::DownloadSnapshotSnafu)?;
@@ -334,6 +340,10 @@ struct DownloadArgs {
     #[argh(switch)]
     /// keep checkpoint files after successful download (for debugging)
     keep_checkpoint: bool,
+
+    #[argh(option)]
+    /// number of concurrent download workers (default: 64)
+    workers: Option<usize>,
 }
 
 /// Turn a user-specified tag string into a Tag object. Tags must start with 'KEY=' and
@@ -504,5 +514,8 @@ mod error {
 
         #[snafu(display("Failed to wait for snapshot: {}", source))]
         WaitSnapshot { source: coldsnap::WaitError },
+
+        #[snafu(display("--workers must be greater than zero"))]
+        InvalidWorkerCount,
     }
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -73,12 +73,14 @@ impl SnapshotDownloader {
     ///   will contain holes that return zeroes when read.
     /// * `progress_bar` is optional, since output to the terminal may not be wanted.
     /// * `checkpoint` specifies checkpointing behavior for resumable downloads.
+    /// * `workers` overrides the number of concurrent download workers (default: 64).
     pub async fn download_to_file<P: AsRef<Path>>(
         &self,
         snapshot_id: &str,
         path: P,
         progress_bar: Option<ProgressBar>,
         checkpoint: Option<CheckpointBehavior>,
+        workers: Option<usize>,
     ) -> Result<()> {
         let checkpoint = checkpoint.unwrap_or(CheckpointBehavior::Disable);
         let path = path.as_ref();
@@ -135,6 +137,7 @@ impl SnapshotDownloader {
             progress_bar,
             checkpoint,
             previously_completed,
+            workers,
         )
         .await?;
         target.finalize().await?;
@@ -147,6 +150,7 @@ impl SnapshotDownloader {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn write_snapshot_blocks(
         &self,
         snapshot: Snapshot,
@@ -155,6 +159,7 @@ impl SnapshotDownloader {
         progress_bar: Option<ProgressBar>,
         checkpoint: CheckpointBehavior,
         previously_completed: Vec<i32>,
+        workers: Option<usize>,
     ) -> Result<()> {
         // Collect errors encountered while downloading blocks, since we can't
         // return a result directly through `for_each_concurrent`.
@@ -199,73 +204,74 @@ impl SnapshotDownloader {
         // Distribute the work across a fixed number of concurrent workers.
         // New threads will be created by the runtime as needed, but we'll
         // only process this many blocks at once to limit resource usage.
-        let download =
-            stream::iter(block_contexts).for_each_concurrent(SNAPSHOT_BLOCK_WORKERS, |context| {
-                let completed_blocks = Arc::clone(&completed_blocks);
-                let last_flush_count = Arc::clone(&last_flush_count);
-                let snapshot_id = snapshot_id_for_flush.clone();
-                let progress_file_path = progress_path_for_flush.clone();
-                async move {
-                    for attempt in 0..SNAPSHOT_BLOCK_ATTEMPTS {
-                        if attempt > 0 {
-                            let backoff = Duration::from_secs(attempt * SNAPSHOT_BLOCK_RETRY_SCALE);
-                            debug!(
-                                "block {}: retry {}/{}, backoff {}s",
+        let worker_count = workers.unwrap_or(SNAPSHOT_BLOCK_WORKERS);
+        ensure!(worker_count > 0, error::InvalidWorkerCountSnafu);
+        debug!("Using {} concurrent download workers", worker_count);
+        let download = stream::iter(block_contexts).for_each_concurrent(worker_count, |context| {
+            let completed_blocks = Arc::clone(&completed_blocks);
+            let last_flush_count = Arc::clone(&last_flush_count);
+            let snapshot_id = snapshot_id_for_flush.clone();
+            let progress_file_path = progress_path_for_flush.clone();
+            async move {
+                for attempt in 0..SNAPSHOT_BLOCK_ATTEMPTS {
+                    if attempt > 0 {
+                        let backoff = Duration::from_secs(attempt * SNAPSHOT_BLOCK_RETRY_SCALE);
+                        debug!(
+                            "block {}: retry {}/{}, backoff {}s",
+                            context.block_index,
+                            attempt,
+                            SNAPSHOT_BLOCK_ATTEMPTS,
+                            backoff.as_secs()
+                        );
+                        time::sleep(backoff).await;
+                    }
+
+                    let block_result = self.download_block(&context).await;
+                    {
+                        let mut block_errors = context.block_errors.lock().expect("poisoned");
+                        if let Err(e) = block_result {
+                            warn!(
+                                "block {}: attempt {}/{} failed: {}",
                                 context.block_index,
-                                attempt,
+                                attempt + 1,
                                 SNAPSHOT_BLOCK_ATTEMPTS,
-                                backoff.as_secs()
+                                e
                             );
-                            time::sleep(backoff).await;
+                            block_errors.insert(context.block_index, e);
+                            continue;
                         }
+                        block_errors.remove(&context.block_index);
+                    }
 
-                        let block_result = self.download_block(&context).await;
-                        {
-                            let mut block_errors = context.block_errors.lock().expect("poisoned");
-                            if let Err(e) = block_result {
-                                warn!(
-                                    "block {}: attempt {}/{} failed: {}",
-                                    context.block_index,
-                                    attempt + 1,
-                                    SNAPSHOT_BLOCK_ATTEMPTS,
-                                    e
-                                );
-                                block_errors.insert(context.block_index, e);
-                                continue;
-                            }
-                            block_errors.remove(&context.block_index);
-                        }
-
-                        if checkpoint == CheckpointBehavior::Disable {
-                            break;
-                        }
-
-                        // Track completion and flush checkpoint periodically
-                        let completed_count = {
-                            let mut completed = completed_blocks.lock().expect("poisoned");
-                            completed.push(context.block_index);
-                            completed.len()
-                        };
-
-                        let should_flush = {
-                            let mut last_flush = last_flush_count.lock().expect("poisoned");
-                            if completed_count - *last_flush >= CHECKPOINT_FLUSH_INTERVAL {
-                                *last_flush = completed_count;
-                                true
-                            } else {
-                                false
-                            }
-                        };
-
-                        if should_flush {
-                            let blocks: Vec<i32> =
-                                completed_blocks.lock().expect("poisoned").clone();
-                            write_progress(&progress_file_path, &snapshot_id, &blocks).await;
-                        }
+                    if checkpoint == CheckpointBehavior::Disable {
                         break;
                     }
+
+                    // Track completion and flush checkpoint periodically
+                    let completed_count = {
+                        let mut completed = completed_blocks.lock().expect("poisoned");
+                        completed.push(context.block_index);
+                        completed.len()
+                    };
+
+                    let should_flush = {
+                        let mut last_flush = last_flush_count.lock().expect("poisoned");
+                        if completed_count - *last_flush >= CHECKPOINT_FLUSH_INTERVAL {
+                            *last_flush = completed_count;
+                            true
+                        } else {
+                            false
+                        }
+                    };
+
+                    if should_flush {
+                        let blocks: Vec<i32> = completed_blocks.lock().expect("poisoned").clone();
+                        write_progress(&progress_file_path, &snapshot_id, &blocks).await;
+                    }
+                    break;
                 }
-            });
+            }
+        });
         download.await;
 
         // At this point, all the concurrent jobs have finished, so all of the Arcs we copied have
@@ -881,6 +887,9 @@ mod error {
             target: String,
             source: std::num::TryFromIntError,
         },
+
+        #[snafu(display("Worker count must be greater than zero"))]
+        InvalidWorkerCount,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ let client = EbsClient::new(&aws_config::from_env().region("us-west-2").load().a
 let downloader = SnapshotDownloader::new(client);
 let path = Path::new("./disk.img");
 
-downloader.download_to_file("snap-1234", &path, None, None)
+downloader.download_to_file("snap-1234", &path, None, None, None)
     .await
     .expect("failed to download snapshot");
 # }


### PR DESCRIPTION
## Summary

The download path hardcodes 64 concurrent workers (`SNAPSHOT_BLOCK_WORKERS`), with no way for callers to override it. This can exceed the EBS Direct API per-snapshot throttle limit (1000 TPS for `GetSnapshotBlock`) on hosts with low-latency connections, and may overwhelm resource-constrained instances.

This change adds a `--workers` flag to the `download` subcommand, matching the existing `--workers` flag already available on `upload`:

* Add `--workers <N>` CLI option to `DownloadArgs` (default: 64)
* Thread the option through `download_to_file` → `write_snapshot_blocks`
* Validate that `--workers` is greater than zero
* Log the worker count at debug level
* Update doctest in `lib.rs` for the new parameter

## Context

The upload subcommand already supports `--workers` ([main.rs:441](https://github.com/awslabs/coldsnap/blob/develop/src/bin/coldsnap/main.rs#L441)). This PR brings download to parity.

## Test plan

* `cargo test` — all 5 tests pass (2 unit + 3 doctests)
* Tested locally with `--workers 16`: 8 GiB snapshot downloaded successfully
* Verified `--workers 0` is rejected with error message
* `--help` shows the new flag correctly