### PR TITLE
Replace assert!/eprintln with snafu error handling in upload path

### DIFF
--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -93,14 +93,14 @@ async fn run() -> Result<()> {
         }
 
         SubCommand::Upload(upload_args) => {
-            if upload_args.workers == Some(0) {
-                eprintln!("Error: --workers must be greater than zero");
-                std::process::exit(1);
-            }
-            if upload_args.client_shards == Some(0) {
-                eprintln!("Error: --client-shards must be greater than zero");
-                std::process::exit(1);
-            }
+            ensure!(
+                upload_args.workers != Some(0),
+                error::InvalidWorkerCountSnafu
+            );
+            ensure!(
+                upload_args.client_shards != Some(0),
+                error::InvalidClientShardsSnafu
+            );
 
             let num_shards = upload_args.client_shards.unwrap_or(1);
             let uploader = if num_shards <= 1 {
@@ -517,5 +517,8 @@ mod error {
 
         #[snafu(display("--workers must be greater than zero"))]
         InvalidWorkerCount,
+
+        #[snafu(display("--client-shards must be greater than zero"))]
+        InvalidClientShards,
     }
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -258,7 +258,7 @@ impl SnapshotUploader {
         // New threads will be created by the runtime as needed, but we'll
         // only process this many blocks at once to limit resource usage.
         let worker_count = workers.unwrap_or(SNAPSHOT_BLOCK_WORKERS);
-        assert!(worker_count > 0, "--workers must be greater than zero");
+        ensure!(worker_count > 0, error::InvalidWorkerCountSnafu);
         debug!(
             "Using {} concurrent upload workers across {} client shards",
             worker_count,
@@ -647,6 +647,9 @@ mod error {
             source: std::num::TryFromIntError,
         },
 
+        #[snafu(display("Worker count must be greater than zero"))]
+        InvalidWorkerCount,
+
         #[snafu(display(
             "Overflowed multiplying {} ({}) and {} ({}) inside a {}",
             left,
@@ -723,13 +726,5 @@ mod test {
     #[should_panic(expected = "need at least one EBS client")]
     fn with_client_shards_rejects_empty() {
         SnapshotUploader::with_client_shards(vec![]);
-    }
-
-    #[test]
-    #[should_panic(expected = "--workers must be greater than zero")]
-    fn worker_count_zero_panics() {
-        // Simulates what happens if workers=Some(0) gets past CLI validation.
-        let count: usize = 0;
-        assert!(count > 0, "--workers must be greater than zero");
     }
 }


### PR DESCRIPTION
## Summary

Follow-up from #452 — the upload command had the same error handling issues that were fixed in the download path:

- `upload.rs:261` used `assert!` for worker count validation, which panics on invalid user input instead of returning a proper error
- `main.rs` used `eprintln`/`std::process::exit(1)` for `--workers 0` and `--client-shards 0` validation, bypassing normal error reporting

This PR replaces both patterns with snafu `ensure!` macros, matching the error handling established in #452.

### Changes

- **`src/upload.rs`**: Replace `assert!(worker_count > 0, ...)` with `ensure!(worker_count > 0, error::InvalidWorkerCountSnafu)` and add `InvalidWorkerCount` variant to upload error enum
- **`src/bin/coldsnap/main.rs`**: Replace two `eprintln`/`exit` blocks with `ensure!` using `InvalidWorkerCountSnafu` and new `InvalidClientShardsSnafu` variant
- Remove synthetic `worker_count_zero_panics` unit test (it re-created the assert inline without calling the actual function)

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — all 13 tests pass (8 unit + 2 CLI + 3 doc)
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — no formatting issues
- [x] CLI validation smoke tests:
  - `coldsnap upload --workers 0 /dev/null` → `--workers must be greater than zero` (exit 1, no panic)
  - `coldsnap upload --client-shards 0 /dev/null` → `--client-shards must be greater than zero` (exit 1, no panic)
- [x] End-to-end round-trip with `--workers 8`:
  - Uploaded a 10 MB random file (`--workers 8`): 20 blocks, all <500ms, 0 errors
  - Downloaded the snapshot back (`--workers 8`)
  - SHA-256 of the first 10 MB of the downloaded 1 GiB image matches the original file exactly (`36b0b32a...`)
  - Snapshot cleaned up after test