### PR TITLE
Guard --omit-zero-blocks behind an explicit acknowledgement: Make it HARD to corrupt disk images with widely used file systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,27 @@ If you want to add tags to the uploaded snapshot, add `--tag Key=k,Value=v` for 
 $ coldsnap upload snap-1234 --tag "Key=MyKeyName,Value=MyKeyValue" --tag "Key=MyOtherKeyName,Value=MyOtherKeyValue"
 ```
 
-If you want to omit blocks of all zeroes when uploading a snapshot, add `--omit-zero-blocks`.
-This was the historical behavior, but is usually incompatible with encrypted EBS snapshots.
-Applications that write zeroes to blocks will expect to read zeroes back, and for that to work, the blocks must be present in the snapshot.
-If unsure, avoid using this option.
+Omitting blocks of all zeroes when uploading a snapshot is dangerous and will almost certainly corrupt your data with nearly all filesystems.
+If, despite that, you want to omit zero blocks, add `--omit-zero-blocks`.
+
+> [!CAUTION]
+> **Omitting zero blocks will almost certainly corrupt your data with nearly all filesystems.**
+>
+> This was the historical behavior, but it is dangerous and is usually
+> incompatible with encrypted EBS snapshots. When a block is omitted, EBS reads
+> it back as zeroes only if nothing on disk depends on the block being
+> physically present. **Nearly all filesystems and on-disk data structures do
+> not meet that requirement**, so omitting zero blocks will corrupt the
+> resulting volume in ways that may not be detected until much later.
+>
+> Do not use this option unless you are 100% certain that no on-disk data
+> structure in your image relies on literal zeros. If you have any doubt, do not
+> use it.
+>
+> Because of how dangerous this is, `--omit-zero-blocks` on its own will refuse
+> to run: it requires an additional, intentionally undocumented flag to be
+> present as an explicit acknowledgement of the risk. That flag is not shown in
+> `--help` and is not documented here by design.
 
 ```
 $ coldsnap upload disk.img --omit-zero-blocks

--- a/src/bin/coldsnap/main.rs
+++ b/src/bin/coldsnap/main.rs
@@ -128,6 +128,11 @@ async fn run() -> Result<()> {
                 !(upload_args.parent_snapshot_id.is_some() && upload_args.kms_key_id.is_some()),
                 error::ParentAndKmsSnafu
             );
+            ensure!(
+                !upload_args.omit_zero_blocks
+                    || upload_args.i_acknowledge_that_this_will_almost_certainly_result_in_data_corruption_with_encrypted_ebs_volumes_unless_i_am_100_percent_sure_that_no_on_disk_data_structure_relies_on_literal_zeros_nearly_all_filesystems_do_not_meet_this_requirement,
+                error::OmitZeroBlocksNotAcknowledgedSnafu
+            );
 
             let progress_bar = build_progress_bar(upload_args.no_progress, "Uploading");
             let zero_blocks = upload_args
@@ -452,6 +457,10 @@ struct UploadArgs {
     /// omit blocks of all zeros when uploading
     omit_zero_blocks: bool,
 
+    #[argh(switch, hidden_help)]
+    /// required acknowledgement when using --omit-zero-blocks that omitting literal zeros can corrupt data on encrypted EBS volumes unless you are certain no on-disk data structure relies on literal zeros
+    i_acknowledge_that_this_will_almost_certainly_result_in_data_corruption_with_encrypted_ebs_volumes_unless_i_am_100_percent_sure_that_no_on_disk_data_structure_relies_on_literal_zeros_nearly_all_filesystems_do_not_meet_this_requirement: bool,
+
     #[argh(option)]
     /// number of concurrent upload workers (default: 64)
     workers: Option<usize>,
@@ -532,5 +541,8 @@ mod error {
 
         #[snafu(display("--parent-snapshot-id and --kms-key-id cannot be used together (EBS StartSnapshot rejects Encrypted + ParentSnapshotId)"))]
         ParentAndKms,
+
+        #[snafu(display("--omit-zero-blocks is dangerous and will almost certainly corrupt your data with nearly all filesystems. It requires an additional, purposefully hidden acknowledgement flag to be present before it will run."))]
+        OmitZeroBlocksNotAcknowledged,
     }
 }


### PR DESCRIPTION
Omitting zero blocks is unsafe with nearly all filesystems, so the flag now refuses to run on its own and expands the documented warning. The acknowledgement it requires is intentionally left undocumented.

The current README does not emphasize enough how unsafe this argument is for nearly all disk images that users are likely to try and upload.